### PR TITLE
Fix #7 -  Whitelist all component libraries in the tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,17 @@ THE SOFTWARE.
           <target>1.8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Jenkins-ClassFilter-Whitelisted>true</Jenkins-ClassFilter-Whitelisted>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Fixes #7. Generally it is a bad idea to package Jenkins classes as libraries instead of plugins (EnvInject Lib mess, for example), but this patch should at least unblock users trying to run the tool with Jenkins 2.102+

@kohsuke I recommend marking all classes in your libraries as Restricted and changing the Group ID before the release. `io.jenkins` is a bad choice for a multi-level repository, because it pollutes the top level in artifactory. I would suggest something like `io.jenkins.devtools.jenkinsfile-runner`

@reviewbybees @jglick @schnatterer 
