### PR TITLE
Docker: Use assembled app from first stage of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM maven:3.5.2 as jenkinsfilerunner-build
 ARG JENKINS_VERSION=2.108
-ADD . /app
+ADD . /jenkinsfile-runner
 RUN \
-  cd app && mvn package \
+  cd /jenkinsfile-runner && mvn package \
   && wget http://mirrors.jenkins.io/war/$JENKINS_VERSION/jenkins.war \
   && unzip jenkins.war -d /tmp/jenkins
 # This is where we would start Jenkins, login in as administrator and install the default plugins.
@@ -14,6 +14,6 @@ RUN mkdir /app
 # For now just copy the plugins from the workspace
 COPY plugins /app/plugins
 COPY --from=jenkinsfilerunner-build /tmp/jenkins /app/jenkins
-COPY app/target/appassembler /app 
+COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app 
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner", "/app/jenkins", "/app/plugins","/workspace"]


### PR DESCRIPTION
Before the "locally" assembled app (i.e. outside of docker build stage) was used.
That lead to failing docker builds, if no local maven built was done
This is also unexpected, as the first stage of the docker build does its own maven build, which has was not used by seconds stage.