### PR TITLE
Docker: Automate plugin installation using Jenkins Docker image

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -3,9 +3,9 @@ You can package Jenkinsfile Runner with a specific Jenkins image and turn that i
 This way, you can ensure people are running Jenkinsfile in the specific Jenkins environment, for example one that's identical to your production environment.
 
 ## Building
-First, follow [the preparation step in main README](README.md#preparation) and create a directory full of plugins. Name it `plugins` and put it next to `Dockerfile`.
+Edit the `plugins.txt` to to include any plugins you'd like to install. See [the Jenkins Docker README](https://github.com/jenkinsci/docker#preinstalling-plugins) for more information.
 
-Then build the Jenkinsfile Runner image like this:
+Then, build the Jenkinsfile Runner image like this:
 
 ```
 docker build -t jenkinsfile-runner:my-production-jenkins --build-arg JENKINS_VERSION=2.108 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
-FROM maven:3.5.2 as jenkinsfilerunner-build
 ARG JENKINS_VERSION=2.108
-ADD . /app
-RUN \
-  cd app && mvn package \
-  && wget http://mirrors.jenkins.io/war/$JENKINS_VERSION/jenkins.war \
-  && unzip jenkins.war -d /tmp/jenkins
-# This is where we would start Jenkins, login in as administrator and install the default plugins.
-# This is a gap intended to be filled with configuration as code
-#JENKINS_HOME=/tmp/plugins java -jar jenkins.war
+FROM maven:3.5.2 as jenkinsfilerunner-build
+ADD . /jenkinsfile-runner
+RUN cd /jenkinsfile-runner && mvn package
 
-FROM openjdk:8-jdk
-RUN mkdir /app 
-# For now just copy the plugins from the workspace
-COPY plugins /app/plugins
-COPY --from=jenkinsfilerunner-build /tmp/jenkins /app/jenkins
-COPY app/target/appassembler /app 
+FROM jenkins/jenkins:${JENKINS_VERSION}
+USER root
+RUN mkdir /app && unzip /usr/share/jenkins/jenkins.war -d /app/jenkins
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app 
 
-ENTRYPOINT ["/app/bin/jenkinsfile-runner", "/app/jenkins", "/app/plugins","/workspace"]
+ENTRYPOINT ["/app/bin/jenkinsfile-runner", "/app/jenkins", "/usr/share/jenkins/ref/plugins", "/workspace"]

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,0 +1,1 @@
+workflow-aggregator:latest


### PR DESCRIPTION
This builds off PR #11 and changes the second stage of the Dockerfile to use the [official Jenkins Docker image](https://github.com/jenkinsci/docker), which comes with a [install-plugins.sh](https://github.com/jenkinsci/docker/blob/master/install-plugins.sh) script to automate plugin installation, allowing the build process to be fully automated. 

I added a plugins.txt that just contains [workflow-aggregator](https://plugins.jenkins.io/workflow-aggregator), which should be enough for most builds.

Test commands:
```
$ docker build -t jenkinsfile-runner --build-arg JENKINS_VERSION=2.108 
<omitted>
Successfully tagged jenkinsfile-runner:latest

$ docker run --rm -v $PWD/test:/workspace jenkinsfile-runner:latest
Started
Running in Durability level: PERFORMANCE_OPTIMIZED
[Pipeline] node
Running on Jenkins in /tmp/jenkinsTests.tmp/jenkins5677417742861147198test/workspace/job
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Declarative: Checkout SCM)
[Pipeline] checkout
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Build)
[Pipeline] echo
Hello world!
[Pipeline] sh
[job] Running shell script
+ ls -la
total 12
drwxr-xr-x 2 root root 4096 Mar 19 05:35 .
drwxr-xr-x 4 root root 4096 Mar 19 05:35 ..
-rw-r--r-- 1 root root  179 Mar 19 05:35 Jenkinsfile
-rw-r--r-- 1 root root    0 Mar 19 05:35 abc
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```