### PR TITLE
Allow for passing worfklow job parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,32 +57,39 @@ Advanced options:
 $ cat ~/foo/Jenkinsfile
 pipeline {
     agent any
+    parameters {
+        string(name: 'param1', defaultValue: '', description: 'Greeting message')
+        string(name: 'param2', defaultValue: '', description: '2nd parameter')
+    }
     stages {
         stage('Build') {
             steps {
                 echo 'Hello world!'
+                echo "message: ${params.param1}"
+                echo "param2: ${params.param2}"
                 sh 'ls -la'
             }
         }
     }
 }
 
-# Usage: jenkinsfile-runner -w <path to war> -p <path to plugins> -f <path to Jenkinsfile>
-$ ./app/target/appassembler/bin/jenkinsfile-runner -w /tmp/jenkins -p /tmp/jenkins_home/plugins -f ~/foo/
+
+# Usage: jenkinsfile-runner -w <path to war> -p <path to plugins> -f <path to Jenkinsfile> [-a "param1=Hello&param2=value2"]
+$ ./app/target/appassembler/bin/jenkinsfile-runner -w /tmp/jenkins -p /tmp/jenkins_home/plugins -f ~/foo/ -a "param1=Hello&param2=value2"
 Started
 Running in Durability level: PERFORMANCE_OPTIMIZED
 Running on Jenkins in /tmp/jenkinsTests.tmp/jenkins8090792616816810094test/workspace/job
 [Pipeline] node
 [Pipeline] {
-[Pipeline] stage
-[Pipeline] { (Declarative: Checkout SCM)
-[Pipeline] checkout
-[Pipeline] }
 [Pipeline] // stage
 [Pipeline] stage
 [Pipeline] { (Build)
 [Pipeline] echo
 Hello world!
+[Pipeline] echo
+message: Hello
+[Pipeline] echo
+param2: value2
 [Pipeline] sh
 [job] Running shell script
 + ls -la
@@ -101,6 +108,10 @@ Finished: SUCCESS
 
 The exit code reflects the result of the build. The `test` directory of this workspace includes a very simple
 example of Jenkinsfile that can be used to demo Jenkinsfile Runner.
+
+Passing parameters defined within `parameters` section of the pipeline is optional. As parameters are ampersand separated,
+you can't pass a value containing ampersand itself as parameter value. 
+
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pipeline {
 }
 
 
-# Usage: jenkinsfile-runner -w <path to war> -p <path to plugins> -f <path to Jenkinsfile> [-a "param1=Hello&param2=value2"]
+# Usage: jenkinsfile-runner -w <path to war> -p <path to plugins> -f <path to Jenkinsfile> [-a "param1=Hello" -a "param2=value2"]
 $ ./app/target/appassembler/bin/jenkinsfile-runner -w /tmp/jenkins -p /tmp/jenkins_home/plugins -f ~/foo/ -a "param1=Hello&param2=value2"
 Started
 Running in Durability level: PERFORMANCE_OPTIMIZED
@@ -109,8 +109,7 @@ Finished: SUCCESS
 The exit code reflects the result of the build. The `test` directory of this workspace includes a very simple
 example of Jenkinsfile that can be used to demo Jenkinsfile Runner.
 
-Passing parameters defined within `parameters` section of the pipeline is optional. As parameters are ampersand separated,
-you can't pass a value containing ampersand itself as parameter value. 
+Passing parameters defined within `parameters` section of the pipeline is optional. 
 
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -109,8 +109,23 @@ Finished: SUCCESS
 The exit code reflects the result of the build. The `test` directory of this workspace includes a very simple
 example of Jenkinsfile that can be used to demo Jenkinsfile Runner.
 
+### Passing parameters
+
+Any parameter values, for parameters defined on workflow job within `parameters` statement
+can be passed to the Jenkinsfile Runner using `-a` or `--arg` switches in key=value format. 
+
 Passing parameters defined within `parameters` section of the pipeline is optional. 
 
+
+```
+$ ./app/target/appassembler/bin/jenkinsfile-runner \
+  -w /tmp/jenkins \
+  -p /tmp/jenkins_home/plugins \
+  -f ~/foo/ \
+  # pipeline has two parameters param1 and param2
+  -a "param1=Hello" \
+  -a "param2=value2"
+```
 
 ## Demo
 

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -66,6 +66,7 @@ public class Bootstrap {
 
 
     @Option(name = "-a", aliases = { "--arg" }, usage = "Parameters to be passed to workflow job. Use multiple -a switches for multiple params")
+    @CheckForNull
     public Map<String,String> workflowParameters;
 
     @Option(name = "-ns", aliases = { "--no-sandbox" }, usage = "Disable workflow job execution within sandbox environment")
@@ -139,6 +140,10 @@ public class Bootstrap {
             } else {
                 System.setProperty(WORKSPACES_DIR_SYSTEM_PROPERTY, this.runWorkspace.getAbsolutePath());
             }
+        }
+
+        if (this.workflowParameters == null){
+            this.workflowParameters = new HashMap<>();
         }
     }
 

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -14,6 +14,10 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -60,6 +64,12 @@ public class Bootstrap {
             "Requires Jenkins 2.119 or above")
     public File runWorkspace;
 
+
+    @Option(name = "-a", aliases = { "--arg" }, usage = "Parameters to be passed to workflow job. Use multiple -a switches for multiple params")
+    public Map<String,String> workflowParameters;
+
+    @Option(name = "-ns", aliases = { "--no-sandbox" }, usage = "Disable workflow job execution within sandbox environment")
+    public boolean noSandBox;
 
     public static void main(String[] args) throws Throwable {
         // break for attaching profiler

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -1,5 +1,7 @@
 package io.jenkins.jenkinsfile.runner;
 
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
 import hudson.model.queue.QueueTaskFuture;
 import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
 import jenkins.model.Jenkins;
@@ -13,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.NoSuchFileException;
+import java.util.stream.Collectors;
 
 /**
  * This code runs with classloader setup to see all the pipeline plugins loaded
@@ -32,7 +35,12 @@ public class Runner {
         w.setDefinition(new CpsScmFlowDefinition(
                 new FileSystemSCM(bootstrap.jenkinsfile.getParent()), bootstrap.jenkinsfile.getName()));
         QueueTaskFuture<WorkflowRun> f = w.scheduleBuild2(0,
-                new SetJenkinsfileLocation(bootstrap.jenkinsfile));
+                new SetJenkinsfileLocation(bootstrap.jenkinsfile, !bootstrap.noSandBox),
+                new ParametersAction(bootstrap.workflowParameters
+                        .entrySet()
+                        .stream()
+                        .map(e -> new StringParameterValue(e.getKey(), e.getValue()))
+                        .collect(Collectors.toList())));
 
         b = f.getStartCondition().get();
 

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/SetJenkinsfileLocation.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/SetJenkinsfileLocation.java
@@ -19,13 +19,15 @@ import java.util.List;
  */
 public class SetJenkinsfileLocation extends InvisibleAction implements CpsFlowFactoryAction2 {
     private final File jenkinsfile;
+    private final Boolean sandboxedExecution;
 
-    public SetJenkinsfileLocation(File jenkinsfile) {
+    public SetJenkinsfileLocation(File jenkinsfile, Boolean sandbox) {
         this.jenkinsfile = jenkinsfile;
+        this.sandboxedExecution = sandbox;
     }
 
     @Override
     public CpsFlowExecution create(FlowDefinition def, FlowExecutionOwner owner, List<? extends Action> actions) throws IOException {
-        return new CpsFlowExecution(FileUtils.readFileToString(jenkinsfile), true, owner);
+        return new CpsFlowExecution(FileUtils.readFileToString(jenkinsfile), this.sandboxedExecution, owner);
     }
 }

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+    parameters {
+        string(name: 'param1', defaultValue: '', description: 'Greeting message')
+        string(name: 'param2', defaultValue: '', description: '2nd parameter')
+    }
+    stages {
+        stage('Build') {
+            steps {
+                echo 'Hello world!'
+                echo "message: ${params.param1}"
+                echo "param2: ${params.param2}"
+                sh 'ls -la'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Feature description

Idea is that `jenkinsfile-runner` can be used for testing of shared libraries with different parameters passed to test pipelines, e.g. same pipeline using shared library functionality should fail or succeed, depending on parameters passed to pipeline job. Parameters are passed using `-a` or `--args`, inspired by @ndeloof comment on https://github.com/kohsuke/jenkinsfile-runner/issues/13

Also, another CLI switch (`-ns or  --no-sandbox`) is added in order to disable sandboxing. Default behaviour is not changed however. 

## Implementation notes

Parameters are passed in following format
`-params="param1=value1&params2=value2"`

CLI parsing is done in such way that parameters are separated by ampersand symbol `&`, hence disallowing this symbol to be used in parameter value. There is safety check  (e.g. passing `-params=value` will result in appropriate error message)

```
root@194280c42eb8:/src# /app/bin/jenkinsfile-runner -w /app/jenkins -p /usr/share/jenkins/ref/plugins -f test -a value
Exception in thread "main" java.lang.RuntimeException: parameters massed be passed in param1=value1&param2=value2 format
        at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.lambda$postConstruct$0(Bootstrap.java:136)
        at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580)
        at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.postConstruct(Bootstrap.java:135)
        at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.main(Bootstrap.java:81)

```

