### PR TITLE
Optimize docker build process by caching maven dependencies

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -8,15 +8,26 @@ Edit the `plugins.txt` to to include any plugins you'd like to install. See [the
 Then, build the Jenkinsfile Runner image like this:
 
 ```
-docker build -t jenkinsfile-runner:my-production-jenkins --build-arg JENKINS_VERSION=2.108 .
+docker build -t jenkinsfile-runner:my-production-jenkins --build-arg JENKINS_VERSION=2.121.1 .
 ```
+
+If you are rebuilding against latest `lts` image, pass `--no-cache` argument to command above
+to avoid using stale layers
 
 The optional `JENKINS_VERSION` specifies the version of Jenkins core.
 
 ## Usage
-Run the image by mounting the directory that contains `Jenkinsfile` into `/workspace`. For example,
+Run the image by providing path to `Jenkinsfile` . For example,
 
-```
-docker run -v~/foo:/workspace jenkinsfile-runner:my-production-jenkins
+```bash
+docker run --rm -v $PWD/test:/workspace jenkinsfile-runner:my-production-jenkins
 ```
 
+Optionally, if you want to change default parameters for plugins or workspace, you can get onto the container
+by overriding entrypoint - binary is placed in `/app/bin/jenkinsfile-runner`
+
+```bash
+$ docker run --rm -it -v $PWD/test:/workspace --entrypoint bash jenkinsfile-runner:my-production-jenkins
+root@dec4c0f12478:/src# cp -r /app/jenkins /tmp/jenkins
+root@dec4c0f12478:/src# /app/bin/jenkinsfile-runner -w /tmp/jenkins -p /usr/share/jenkins/ref/plugins -f /workspace
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,20 @@
-ARG JENKINS_VERSION=2.108
+ARG JENKINS_VERSION=2.121.1
+
+FROM maven:3.5.2 as jenkinsfilerunner-mvncache
+ADD pom.xml /src/pom.xml
+ADD app/pom.xml /src/app/pom.xml
+ADD bootstrap/pom.xml /src/bootstrap/pom.xml
+ADD setup/pom.xml /src/setup/pom.xml
+ADD payload/pom.xml /src/payload/pom.xml
+ADD payload-dependencies/pom.xml /src/payload-dependencies/pom.xml
+
+WORKDIR /src
+ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
+RUN mvn compile dependency:resolve dependency:resolve-plugins
+
 FROM maven:3.5.2 as jenkinsfilerunner-build
+ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
+COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD . /jenkinsfile-runner
 RUN cd /jenkinsfile-runner && mvn package
 
@@ -8,6 +23,9 @@ USER root
 RUN mkdir /app && unzip /usr/share/jenkins/jenkins.war -d /app/jenkins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
-COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app 
+COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app
 
-ENTRYPOINT ["/app/bin/jenkinsfile-runner", "/app/jenkins", "/usr/share/jenkins/ref/plugins", "/workspace"]
+ENTRYPOINT ["/app/bin/jenkinsfile-runner", \
+           "-w", "/app/jenkins",\
+          "-p", "/usr/share/jenkins/ref/plugins",\
+          "-f", "/workspace"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ARG JENKINS_VERSION=2.121.1
 
-FROM maven:3.5.2 as jenkinsfilerunner-mvncache
+# Define maven version for other stages
+FROM maven:3.5.2 as maven
+
+FROM maven as jenkinsfilerunner-mvncache
 ADD pom.xml /src/pom.xml
 ADD app/pom.xml /src/app/pom.xml
 ADD bootstrap/pom.xml /src/bootstrap/pom.xml
@@ -12,7 +15,7 @@ WORKDIR /src
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 RUN mvn compile dependency:resolve dependency:resolve-plugins
 
-FROM maven:3.5.2 as jenkinsfilerunner-build
+FROM maven as jenkinsfilerunner-build
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD . /jenkinsfile-runner
@@ -26,6 +29,6 @@ RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner", \
-           "-w", "/app/jenkins",\
-          "-p", "/usr/share/jenkins/ref/plugins",\
-          "-f", "/workspace"]
+            "-w", "/app/jenkins",\
+            "-p", "/usr/share/jenkins/ref/plugins",\
+            "-f", "/workspace"]

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,1 +1,1 @@
-workflow-aggregator:latest
+pipeline-model-definition:latest


### PR DESCRIPTION
Retesting docker build process took me a while if there is an syntax error in the code or such. This approach caches all of maven dependencies in separate layer, thus shortening time to repetitively build container. Also this PR updates `Dockerfile` to use -x style parameters implemented in https://github.com/kohsuke/jenkinsfile-runner/pull/21. 