### PR TITLE
Copy all files from workspace

### DIFF
--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/FileSystemSCM.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/FileSystemSCM.java
@@ -10,6 +10,7 @@ import hudson.scm.NullChangeLogParser;
 import hudson.scm.PollingResult;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
+import hudson.util.DirScanner;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -34,7 +35,7 @@ public class FileSystemSCM extends SCM {
 
     @Override
     public void checkout(@Nonnull Run<?, ?> build, @Nonnull Launcher launcher, @Nonnull FilePath workspace, @Nonnull TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
-        new FilePath(dir).copyRecursiveTo(workspace);
+        new FilePath(dir).copyRecursiveTo(new DirScanner.Glob("**/*", null, false), workspace, "**/*");
     }
 
     /**


### PR DESCRIPTION
By default, `copyRecursiveTo` [excludes](https://github.com/apache/ant/blob/ANT_193/src/main/org/apache/tools/ant/DirectoryScanner.java#L148) a whole slew of files. In particular, it excludes the `.git` directory. In the usage of `jenkinsfile-runner` as part of a knative build, this means the Jenkinsfile is required to clone the repo again to access git history (as required by Jenkins X). This PR makes a small change to copy across all files into the Jenkins workspace.