### PR TITLE
[JENKINS-54351] Avoid skipping enforcer in builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ payload-dependencies/target/
 payload/target/
 setup/target/
 cwp-cli-1.3.jar
+demo/cwp/tmp/output
+demo/cwp/tmp/prebuild

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -14,12 +14,12 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.33</version>
+      <version>2.0.31</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
+      <version>2.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -21,16 +21,6 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
       <version>${jenkins.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>args4j</groupId>
-          <artifactId>args4j</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -21,6 +21,16 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
       <version>${jenkins.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>args4j</groupId>
+          <artifactId>args4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -75,21 +85,4 @@
       <version>1.39</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <!-- Bypassing problem like this:
-[INFO] - - - maven-enforcer-plugin:3.0.0-M1:enforce (display-info) @ jenkinsfile-runner - - -
-[WARNING] Rule 3: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
-Failed while enforcing RequireUpperBoundDeps. The error(s) are [
-]
-          -->
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/payload/pom.xml
+++ b/payload/pom.xml
@@ -25,18 +25,6 @@
            </programs>
          </configuration>
        </plugin>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <!-- Bypassing problem like this:
-[INFO] - - - maven-enforcer-plugin:3.0.0-M1:enforce (display-info) @ jenkinsfile-runner - - -
-[WARNING] Rule 3: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
-Failed while enforcing RequireUpperBoundDeps. The error(s) are [
-]
-          -->
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
[JENKINS-54351](https://issues.jenkins-ci.org/browse/JENKINS-54351)

Avoid skipping the enforcer in builds. Exclude a couple dependencies that were raising upper bound errors.

@oleg-nenashev @fcojfernandez 