### PR TITLE
[JENKINS-54375] Fix javadoc error and include its generation in build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.0-beta-2] - 2018-12-17
+- [[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)] Fix Javadoc error and include Javadoc generation in build.
+
 ## [1.0-beta-1] - 2018-12-17
 - [[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)] First release.
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,19 @@ THE SOFTWARE.
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/util/HudsonHomeLoader.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/util/HudsonHomeLoader.java
@@ -36,7 +36,7 @@ import java.net.URL;
 import javax.annotation.CheckForNull;
 
 /**
- * Controls how a {@link HudsonTestCase} initializes <tt>JENKINS_HOME</tt>.
+ * Controls how <tt>JENKINS_HOME</tt> is initialized.
  *
  * @author Kohsuke Kawaguchi
  */


### PR DESCRIPTION
[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)

Fix a Javadoc error and include the generation during the build.

@oleg-nenashev @fcojfernandez 