### PR TITLE
[JENKINS-54375] Exclude Javadoc generation from package phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.0-beta-3] - 2018-12-17
+- [[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)] Exclude Javadoc generation in build.
+
 ## [1.0-beta-2] - 2018-12-17
 - [[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)] Fix Javadoc error and include Javadoc generation in build.
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,19 +121,6 @@ THE SOFTWARE.
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
[https://issues.jenkins-ci.org/browse/JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)