### PR TITLE
[JENKINS-54375] Fix classloading after changing Maven coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.0-beta-4] - 2018-12-18
+- [[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)] Fix bug after changing Maven coordinates.
+
 ## [1.0-beta-3] - 2018-12-17
 - [[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)] Exclude Javadoc generation in build.
 

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/App.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/App.java
@@ -21,7 +21,7 @@ public class App implements IApp {
             public void evaluate() throws Throwable {
                 // insert the payload
                 ClassLoader cl = new ClassLoaderBuilder(rule.jenkins.getPluginManager().uberClassLoader)
-                        .collectJars(new File(bootstrap.appRepo, "io/jenkins/jenkinsfile-runner-payload"))
+                        .collectJars(new File(bootstrap.appRepo, "io/jenkins/jenkinsfile-runner/payload"))
                         .make();
 
                 Class<?> c = cl.loadClass("io.jenkins.jenkinsfile.runner.Runner");


### PR DESCRIPTION
[JENKINS-54375](https://issues.jenkins-ci.org/browse/JENKINS-54375)

Adapt location of folder to pick JAR files after changing the Maven coordinates.

@oleg-nenashev @fcojfernandez 