### PR TITLE
[JENKINS-54425] Avoid warnings in build logs

### DIFF
--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerRule.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerRule.java
@@ -1,5 +1,6 @@
 package io.jenkins.jenkinsfile.runner;
 
+import hudson.ClassicPluginStrategy;
 import hudson.security.ACL;
 import jenkins.slaves.DeprecatedAgentProtocolMonitor;
 import org.eclipse.jetty.security.HashLoginService;
@@ -80,7 +81,8 @@ public class JenkinsfileRunnerRule extends JenkinsEmbedder {
      * We don't want to clutter console with log messages, so kill of any unimportant ones.
      */
     private void setLogLevels() {
-        Logger.getLogger("").setLevel(Level.SEVERE);
+        Logger.getLogger("").setLevel(Level.WARNING);
+        Logger.getLogger(ClassicPluginStrategy.class.getName()).setLevel(Level.SEVERE);
         Logger l = Logger.getLogger(DeprecatedAgentProtocolMonitor.class.getName());
         l.setLevel(Level.OFF);
         noGc.add(l);    // the configuration will be lost if Logger gets GCed.

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerRule.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerRule.java
@@ -80,7 +80,7 @@ public class JenkinsfileRunnerRule extends JenkinsEmbedder {
      * We don't want to clutter console with log messages, so kill of any unimportant ones.
      */
     private void setLogLevels() {
-        Logger.getLogger("").setLevel(Level.WARNING);
+        Logger.getLogger("").setLevel(Level.SEVERE);
         Logger l = Logger.getLogger(DeprecatedAgentProtocolMonitor.class.getName());
         l.setLevel(Level.OFF);
         noGc.add(l);    // the configuration will be lost if Logger gets GCed.

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerRule.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerRule.java
@@ -82,6 +82,7 @@ public class JenkinsfileRunnerRule extends JenkinsEmbedder {
      */
     private void setLogLevels() {
         Logger.getLogger("").setLevel(Level.WARNING);
+        // Prevent warnings for plugins with old plugin POM (JENKINS-54425)
         Logger.getLogger(ClassicPluginStrategy.class.getName()).setLevel(Level.SEVERE);
         Logger l = Logger.getLogger(DeprecatedAgentProtocolMonitor.class.getName());
         l.setLevel(Level.OFF);


### PR DESCRIPTION
In general we don't want warnings in build logs, since we are only interested there in the results of our Jenkinsfiles.

**BEFORE**
![screen shot 2018-12-20 at 09 38 05](https://user-images.githubusercontent.com/6572596/50282728-050cce00-0454-11e9-9cfc-e98b4cf70963.png)

**AFTER**
![screen shot 2018-12-20 at 11 37 01](https://user-images.githubusercontent.com/6572596/50282742-11912680-0454-11e9-8ba9-74ee76ea7356.png)
