### PR TITLE
[JENKINS-54426] Fix failures in Java 11

### DIFF
--- a/demo/cwp-jdk11/Jenkinsfile
+++ b/demo/cwp-jdk11/Jenkinsfile
@@ -1,0 +1,9 @@
+
+stage('Read Evergreen YAML') {
+    node {
+        // Discover core version using Pipeline utility steps
+        sh 'wget https://raw.githubusercontent.com/jenkins-infra/evergreen/master/services/essentials.yaml'
+        def essentialsYaml = readYaml(file: "essentials.yaml")
+        echo "Jenkins Evergreen uses the following Core version: ${essentialsYaml.spec.core.version}"
+    }
+}

--- a/demo/cwp-jdk11/Makefile
+++ b/demo/cwp-jdk11/Makefile
@@ -14,6 +14,7 @@ clean:
 	rm -rf source
 	rm -rf out
 
+
 .copySource:
 	rsync -av --exclude='demo' $(shell pwd)/../../ $(shell pwd)/source
 
@@ -44,4 +45,6 @@ build: .copySource .build .buildImage
 buildInDocker: .copySource .buildInDocker .buildImage
 
 run:
-	docker run --rm -v $(shell pwd)/Jenkinsfile:/workspace/Jenkinsfile ${JENKINSFILE_RUNNER_TAG}
+	docker run --rm -v $(shell pwd)/Jenkinsfile:/workspace/Jenkinsfile \
+	-e JAVA_OPTS="-p /usr/share/jenkins/ref/java_cp/jaxb-api.jar:/usr/share/jenkins/ref/java_cp/javax.activation.jar --add-modules java.xml.bind,java.activation,java.sql -cp /usr/share/jenkins/ref/java_cp/jaxb-impl.jar:/usr/share/jenkins/ref/java_cp/jaxb-core.jar" \
+	${JENKINSFILE_RUNNER_TAG}

--- a/demo/cwp-jdk11/README.md
+++ b/demo/cwp-jdk11/README.md
@@ -3,7 +3,7 @@ Jenkinsfile Runner demo
 
 This demo demonstrates building of Jenkinsfile Runner Docker images
 with [Custom WAR Packager](https://github.com/jenkinsci/custom-war-packager/)
-using JDK 11 based Docker image.
+using a JDK 11 based Docker image.
 This demo bundles some plugins so that it demonstrates a Pipeline execution.
 
 To build the Docker image, run `make clean build`

--- a/demo/cwp-jdk11/README.md
+++ b/demo/cwp-jdk11/README.md
@@ -1,0 +1,16 @@
+Jenkinsfile Runner demo
+===
+
+This demo demonstrates building of Jenkinsfile Runner Docker images
+with [Custom WAR Packager](https://github.com/jenkinsci/custom-war-packager/)
+using JDK 11 based Docker image.
+This demo bundles some plugins so that it demonstrates a Pipeline execution.
+
+To build the Docker image, run `make clean build`
+
+You can experiment with other `Jenkinsfile`s if needed.
+Once the Docker image is built, the demo Jenkinsfile Runner can be started simply as...
+
+    docker run --rm -v $PWD/Jenkinsfile:/workspace/Jenkinsfile jenkins-experimental/jenkinsfile-runner-demo
+
+See a more complex demo [here](https://github.com/jenkinsci/custom-war-packager/blob/master/demo/jenkinsfile-runner/)

--- a/demo/cwp-jdk11/packager-config.yml
+++ b/demo/cwp-jdk11/packager-config.yml
@@ -42,7 +42,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-support"
     source:
-      version: "3.0" # TO-DO: Maybe this should be to payload-dependencies ?
+      version: "3.0" # TO-DO: Maybe this should be into payload-dependencies ?
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-utility-steps"
     source:

--- a/demo/cwp-jdk11/packager-config.yml
+++ b/demo/cwp-jdk11/packager-config.yml
@@ -1,0 +1,84 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        dir: ./source
+    docker:
+      base: "jenkins/jenkins:jdk11"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.158"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.30"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.14"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-support"
+    source:
+      version: "3.0" # TO-DO: Maybe this should be to payload-dependencies ?
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.1"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}


### PR DESCRIPTION
[JENKINS-54426](https://issues.jenkins-ci.org/browse/JENKINS-54426)

Based in #41 

- Use platform classloader when JDK 9+ to be able to access platform classes.
- Include a demo that uses a base image with JDK11.

