### PR TITLE
[JENKINS-55703] - Add a  “—runWorkspace” parameter to define the workspace 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,10 @@ COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app
 
+VOLUME /build
+
 ENTRYPOINT ["/app/bin/jenkinsfile-runner", \
             "-w", "/app/jenkins",\
             "-p", "/usr/share/jenkins/ref/plugins",\
-            "-f", "/workspace"]
+            "-f", "/workspace", \
+            "--runWorkspace", "/build"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ JENKINS_HOME=/tmp/jenkins_home java -jar jenkins.war
 Say you have your Git repository checked out at `~/foo` that contains `Jenkinsfile` and your source code.
 You can now run Jenkinsfile Runner like this:
 
+### Usage in Docker
+
+See the demos.
+Once Docker image is built, Jenkinsfile Runner can be launched simply as...
+
+```
+    docker run --rm -v $(shell pwd)/Jenkinsfile:/workspace/Jenkinsfile ${JENKINSFILE_RUNNER_IMAGE}
+```
+
+Advanced options:
+
+* `JAVA_OPTS` environment variable can be passed to pass extra options to the image
+* In the suggested `Dockerfile` the master workspace is mapped to `/build`.
+  This directory can be exposed as a volume.
+
+### Usage in command-line
+
 ```
 $ cat ~/foo/Jenkinsfile
 pipeline {

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -5,6 +5,7 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +48,15 @@ public class Bootstrap {
      */
     @Option(name = "-f", aliases = { "--file" }, usage = "Path to Jenkinsfile (or directory containing a Jenkinsfile) to run, default to ./Jenkinsfile.")
     public File jenkinsfile;
+
+    /**
+     * Workspace for the Run
+     */
+    @CheckForNull
+    @Option(name = "--runWorkspace", usage = "Path to the workspace of the run to be used within the node{} context. " +
+            "It applies to both Jenkins master and agents (or side containers) if any. " +
+            "Requires Jenkins 2.119 or above")
+    public File runWorkspace;
 
 
     public static void main(String[] args) throws Throwable {
@@ -107,6 +117,15 @@ public class Bootstrap {
                 String shortname = line.substring(0,i);
                 String version = line.substring(i+1);
                 installPlugin(shortname, version);
+            }
+        }
+
+        if (this.runWorkspace != null){
+            if (System.getProperty("jenkins.model.Jenkins.workspacesDir") != null) {
+                //TODO(oleg_nenashev): It would have been better to keep it other way, but made it as is to retain compatibility
+                System.out.println("Ignoring the --runWorkspace argument, because an explicit System property is set");
+            } else {
+                System.setProperty("jenkins.model.Jenkins.workspacesDir", this.runWorkspace.getAbsolutePath());
             }
         }
     }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -23,6 +23,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class Bootstrap {
 
     public static final long CACHE_EXPIRE = System.currentTimeMillis() - 24 * 3600 * 1000;
+    private static final String WORKSPACES_DIR_SYSTEM_PROPERTY = "jenkins.model.Jenkins.workspacesDir";
+
     /**
      * This system property is set by the bootstrap script created by appassembler Maven plugin
      * to point to a local Maven repository.
@@ -121,11 +123,11 @@ public class Bootstrap {
         }
 
         if (this.runWorkspace != null){
-            if (System.getProperty("jenkins.model.Jenkins.workspacesDir") != null) {
+            if (System.getProperty(WORKSPACES_DIR_SYSTEM_PROPERTY) != null) {
                 //TODO(oleg_nenashev): It would have been better to keep it other way, but made it as is to retain compatibility
-                System.out.println("Ignoring the --runWorkspace argument, because an explicit System property is set");
+                System.out.println("Ignoring the --runWorkspace argument, because an explicit System property is set (-D" + WORKSPACES_DIR_SYSTEM_PROPERTY + ")");
             } else {
-                System.setProperty("jenkins.model.Jenkins.workspacesDir", this.runWorkspace.getAbsolutePath());
+                System.setProperty(WORKSPACES_DIR_SYSTEM_PROPERTY, this.runWorkspace.getAbsolutePath());
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@ THE SOFTWARE.
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Also, the new parameter is enabled by default for vanilla Docker images.



