### PR TITLE
Update shebang to find bash from the environment, and ad…

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+# Jenkinsfile Runner Tests
+
+## Running the testst on macOS
+The version of shUnit2 we are using does not work with the default bash shell on macOS. 
+
+In order to get tests to run, we recommend upgrading your bash shell by following the instructions here [Upgrading bash on macOs](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 current_directory=$(pwd)


### PR DESCRIPTION
…d instructions for Mac workaround

Our tests do not work by default on Mac as we are using an unreleased version of shUnit2 which will not run in the default bash shell on macOS.  I was able to workaround this by adding a new more modern version of bash, and updating the shebang in tests.sh to find bash via the environment rather than hardcoding it.

I've added a README.md with instructions related to this.
