### PR TITLE
Fix demo/cwp-jdk11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ setup/.settings/
 tests/.classpath
 tests/.project
 tests/.settings/
+demo/cwp-jdk11/out/
+demo/cwp-jdk11/source/
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ demo/cwp/tmp/output
 demo/cwp/tmp/prebuild
 demo/cwp/out
 demo/databound/out
+demo/databound/source
 demo/cwp/source
 .idea
 *.iml

--- a/demo/cwp-jdk11/Makefile
+++ b/demo/cwp-jdk11/Makefile
@@ -45,6 +45,4 @@ build: .copySource .build .buildImage
 buildInDocker: .copySource .buildInDocker .buildImage
 
 run:
-	docker run --rm -v $(shell pwd)/Jenkinsfile:/workspace/Jenkinsfile \
-	-e JAVA_OPTS="-p /usr/share/jenkins/ref/java_cp/jaxb-api.jar:/usr/share/jenkins/ref/java_cp/javax.activation.jar --add-modules java.xml.bind,java.activation,java.sql -cp /usr/share/jenkins/ref/java_cp/jaxb-impl.jar:/usr/share/jenkins/ref/java_cp/jaxb-core.jar" \
-	${JENKINSFILE_RUNNER_TAG}
+	docker run --rm -v $(shell pwd)/Jenkinsfile:/workspace/Jenkinsfile ${JENKINSFILE_RUNNER_TAG}

--- a/demo/cwp-jdk11/packager-config.yml
+++ b/demo/cwp-jdk11/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:jdk11"
+      base: "jenkins/jenkins:2.164-jdk11"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.158"
+    version: "2.164"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/demo/cwp/packager-config.yml
+++ b/demo/cwp/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.164"
+      base: "jenkins/jenkins:2.150.2"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.164"
+    version: "2.150.2"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/demo/cwp/packager-config.yml
+++ b/demo/cwp/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.138.2"
+      base: "jenkins/jenkins:2.164"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.2"
+    version: "2.164"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/demo/databound/packager-config.yml
+++ b/demo/databound/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.164"
+      base: "jenkins/jenkins:2.150.2"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.164"
+    version: "2.150.2"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/demo/databound/packager-config.yml
+++ b/demo/databound/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.138.2"
+      base: "jenkins/jenkins:2.164"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.2"
+    version: "2.164"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"


### PR DESCRIPTION
After executing the demo for cwp-jdk11, I've got the following error message:
```
Error occurred during initialization of boot layer
java.lang.module.FindException: Module java.xml.bind not found
Makefile:48: recipe for target 'run' failed
make: *** [run] Error 1
```
JAXB is not part of Jenkins anymore since it's going to be detached to a new plugin. This PR pretends to fix the demo