### PR TITLE
[JENKINS-54352] Test negative scenarios

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,7 @@ clean:
 
 init:
 	# TODO replace with first version of the test framework
-	git clone https://github.com/jenkinsci/jenkinsfile-runner-test-framework .jenkinsfile-runner-test-framework && cd .jenkinsfile-runner-test-framework && git checkout 0ed9ea7a43161ad97764db566d52412dd2dab621
+	git clone https://github.com/jenkinsci/jenkinsfile-runner-test-framework .jenkinsfile-runner-test-framework && cd .jenkinsfile-runner-test-framework && git checkout 4ed3c35650fe880345b77ee4776b29bd00944fb3
 	rsync -avq --exclude-from='exclude-rsync.txt' $(shell pwd)/../ $(shell pwd)/.jenkinsfile-runner-test-framework/source
 	$(MAKE) -C .jenkinsfile-runner-test-framework
 
@@ -16,3 +16,4 @@ test:
 	./tests-cwp.sh
 	./tests-cwp-jdk11.sh
 	./tests-vanilla.sh
+	./tests-negative-scenarios.sh

--- a/tests/test_resources/negative-scenarios/config/packager-config-plugin-collision.yml
+++ b/tests/test_resources/negative-scenarios/config/packager-config-plugin-collision.yml
@@ -1,0 +1,80 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        dir: "./.jenkinsfile-runner-test-framework/source"
+    docker:
+      base: "jenkins/jenkins:2.150.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.150.2"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.27"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.10"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.1"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}

--- a/tests/test_resources/negative-scenarios/config/packager-config-valid.yml
+++ b/tests/test_resources/negative-scenarios/config/packager-config-valid.yml
@@ -1,0 +1,80 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        dir: "./.jenkinsfile-runner-test-framework/source"
+    docker:
+      base: "jenkins/jenkins:2.150.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.150.2"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.27"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.1"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}

--- a/tests/test_resources/negative-scenarios/test_pipeline_execution_fails/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_pipeline_execution_fails/Jenkinsfile
@@ -1,0 +1,3 @@
+node {
+    currentBuild.result = 'FAILED'
+}

--- a/tests/test_resources/negative-scenarios/test_pipeline_execution_fails_bad_syntax/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_pipeline_execution_fails_bad_syntax/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     }
     stages {
         stage('Build') {
+            // Missing steps, then it fails
             echo 'Hello world!'
             echo "Value for param1: ${params.param1}"
             echo "Value for param2: ${params.param2}"

--- a/tests/test_resources/negative-scenarios/test_pipeline_execution_fails_bad_syntax/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_pipeline_execution_fails_bad_syntax/Jenkinsfile
@@ -1,0 +1,14 @@
+pipeline {
+    agent any
+    parameters {
+        string(name: 'param1', defaultValue: '', description: 'Greeting message')
+        string(name: 'param2', defaultValue: '', description: '2nd parameter')
+    }
+    stages {
+        stage('Build') {
+            echo 'Hello world!'
+            echo "Value for param1: ${params.param1}"
+            echo "Value for param2: ${params.param2}"
+        }
+    }
+}

--- a/tests/test_resources/negative-scenarios/test_pipeline_execution_hangs/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_pipeline_execution_hangs/Jenkinsfile
@@ -1,0 +1,7 @@
+stage('Read Evergreen YAML') {
+    node {
+        while(true) {
+            // it hangs
+        }
+    }
+}

--- a/tests/test_resources/negative-scenarios/test_pipeline_execution_is_unstable/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_pipeline_execution_is_unstable/Jenkinsfile
@@ -1,0 +1,3 @@
+node {
+    currentBuild.result = 'UNSTABLE'
+}

--- a/tests/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile
@@ -1,0 +1,9 @@
+
+stage('Read Evergreen YAML') {
+    node {
+        // Discover core version using Pipeline utility steps
+        sh 'wget https://raw.githubusercontent.com/jenkins-infra/evergreen/master/services/essentials.yaml'
+        def essentialsYaml = readYaml(file: "essentials.yaml")
+        echo "Jenkins Evergreen uses the following Core version: ${essentialsYaml.spec.core.version}"
+    }
+}

--- a/tests/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile
@@ -1,4 +1,4 @@
-// This Jenkinsfile will not be executed because this tests has a conflict in CWP configuration. Using the simplest one
+// This Jenkinsfile will not be executed because this test has a conflict in CWP configuration. Using the simplest one
 node {
     currentBuild.result = 'SUCCESS'
 }

--- a/tests/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile
+++ b/tests/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile
@@ -1,9 +1,4 @@
-
-stage('Read Evergreen YAML') {
-    node {
-        // Discover core version using Pipeline utility steps
-        sh 'wget https://raw.githubusercontent.com/jenkins-infra/evergreen/master/services/essentials.yaml'
-        def essentialsYaml = readYaml(file: "essentials.yaml")
-        echo "Jenkins Evergreen uses the following Core version: ${essentialsYaml.spec.core.version}"
-    }
+// This Jenkinsfile will not be executed because this tests has a conflict in CWP configuration. Using the simplest one
+node {
+    currentBuild.result = 'SUCCESS'
 }

--- a/tests/tests-negative-scenarios.sh
+++ b/tests/tests-negative-scenarios.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+current_directory=$(pwd)
+test_framework_directory="$current_directory/.jenkinsfile-runner-test-framework"
+working_directory="$test_framework_directory/work-negative"
+
+version="256.0-test"
+jenkinsfile_runner_valid_tag="jenkins-experimental/jenkinsfile-runner-test-image"
+jenkinsfile_runner_invalid_tag="jenkins-experimental/jenkinsfile-runner-test-invalid-image"
+
+. $test_framework_directory/init-jfr-test-framework.inc
+
+oneTimeSetUp() {
+  rm -rf "$working_directory"
+  mkdir -p "$working_directory"
+  downloaded_cwp_jar=$(download_cwp "$working_directory")
+
+  # docker image to test the plugin version collision
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/negative-scenarios/config/packager-config-plugin-collision.yml" "$jenkinsfile_runner_invalid_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_invalid_tag" "$jfr_tag"
+
+  # docker image for the rest of tests
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/negative-scenarios/config/packager-config-valid.yml" "$jenkinsfile_runner_valid_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_valid_tag" "$jfr_tag"
+}
+
+setUp() {
+  # timeout per test
+  if [[ ${_shunit_test_} == *"test_pipeline_execution_hangs"* ]]
+  then
+    set_timeout 10
+  elif [[ ${_shunit_test_} == *"plugin_versions_collision"* ]]
+  then
+    set_timeout 15
+  else
+    set_timeout -1
+  fi
+}
+
+test_pipeline_execution_fails_bad_syntax() {
+  run_jfr_docker_image "$jenkinsfile_runner_valid_tag" "$current_directory/test_resources/negative-scenarios/test_pipeline_execution_fails_bad_syntax/Jenkinsfile"
+  execution_success "$?"
+  logs_not_contains "[Pipeline] End of Pipeline"
+  logs_contains "Finished: FAILURE"
+  logs_contains "Unknown stage section"
+}
+
+test_pipeline_execution_fails() {
+  run_jfr_docker_image "$jenkinsfile_runner_valid_tag" "$current_directory/test_resources/negative-scenarios/test_pipeline_execution_fails/Jenkinsfile"
+  jenkinsfile_execution_should_fail "$?"
+}
+
+test_pipeline_execution_is_unstable() {
+  run_jfr_docker_image "$jenkinsfile_runner_valid_tag" "$current_directory/test_resources/negative-scenarios/test_pipeline_execution_is_unstable/Jenkinsfile"
+  jenkinsfile_execution_should_be_unstable "$?"
+}
+
+test_pipeline_execution_hangs() {
+  result=$(eval private_execution_after_timeout "$jenkinsfile_runner_valid_tag" "$current_directory/test_resources/negative-scenarios/test_pipeline_execution_hangs/Jenkinsfile")
+  execution_success "$?"
+}
+
+test_plugin_versions_collision() {
+  result=$(eval private_execution_after_timeout "$jenkinsfile_runner_invalid_tag" "$current_directory/test_resources/negative-scenarios/test_plugin_versions_collision/Jenkinsfile")
+  execution_success "$?"
+  logs_contains "Pipeline: Step API v2.10 is older than required" "$result"
+}
+
+#function to be used in test where a timeout is expected
+private_execution_after_timeout() {
+  set +e
+  result=$(run_jfr_docker_image "$1" "$2")
+  if [ "0" != "$?" ]
+  then
+    echo "$result"
+    # expected that the execution fails because of the timeout
+    return 0
+  else
+    return 1
+  fi
+  set -e
+}
+
+oneTimeTearDown() {
+  # remove docker with invalid configuration
+  docker_id=$(docker images -q "$jenkinsfile_runner_invalid_tag")
+  docker rmi -f "$docker_id"
+}
+
+init_framework


### PR DESCRIPTION
See [JENKINS-54352](https://issues.jenkins-ci.org/browse/JENKINS-54352)

Adds test for negative scenarios:

- Set of plugins where some versions collide
- Jenkinsfile with wrong syntax
- Failure in the execution
- Pipeline execution hangs