### PR TITLE
Fix CI execution

### DIFF
--- a/tests/exclude-rsync.txt
+++ b/tests/exclude-rsync.txt
@@ -1,2 +1,3 @@
 demo
 tests/jenkinsfile-runner-test-framework
+**/.git*

--- a/tests/tests-negative-scenarios.sh
+++ b/tests/tests-negative-scenarios.sh
@@ -85,6 +85,11 @@ private_execution_after_timeout() {
 
 oneTimeTearDown() {
   # force docker termination in case it is still executing
+  docker_id=$(docker ps -aqf "name=$jenkinsfile_runner_valid_tag")
+  if [ ! -z "$docker_id" ]
+  then
+    docker stop -t 1 "$docker_id"
+  fi
   docker_id=$(docker ps -aqf "name=$jenkinsfile_runner_invalid_tag")
   if [ ! -z "$docker_id" ]
   then
@@ -92,6 +97,11 @@ oneTimeTearDown() {
   fi
 
   # remove docker with invalid configuration
+  docker_id=$(docker images -q "$jenkinsfile_runner_valid_tag")
+  if [ ! -z "$docker_id" ]
+  then
+    docker rmi -f "$docker_id"
+  fi
   docker_id=$(docker images -q "$jenkinsfile_runner_invalid_tag")
   if [ ! -z "$docker_id" ]
   then

--- a/tests/tests-negative-scenarios.sh
+++ b/tests/tests-negative-scenarios.sh
@@ -53,7 +53,8 @@ test_pipeline_execution_fails() {
 
 test_pipeline_execution_is_unstable() {
   run_jfr_docker_image "$jenkinsfile_runner_valid_tag" "$current_directory/test_resources/negative-scenarios/test_pipeline_execution_is_unstable/Jenkinsfile"
-  jenkinsfile_execution_should_be_unstable "$?"
+  execution_success "$?"
+  logs_contains "Finished: UNSTABLE"
 }
 
 test_pipeline_execution_hangs() {
@@ -80,6 +81,22 @@ private_execution_after_timeout() {
     return 1
   fi
   set -e
+}
+
+oneTimeTearDown() {
+  # force docker termination in case it is still executing
+  docker_id=$(docker ps -aqf "name=$jenkinsfile_runner_invalid_tag")
+  if [ ! -z "$docker_id" ]
+  then
+    docker stop -t 1 "$docker_id"
+  fi
+
+  # remove docker with invalid configuration
+  docker_id=$(docker images -q "$jenkinsfile_runner_invalid_tag")
+  if [ ! -z "$docker_id" ]
+  then
+    docker rmi -f "$docker_id"
+  fi
 }
 
 init_framework

--- a/tests/tests-negative-scenarios.sh
+++ b/tests/tests-negative-scenarios.sh
@@ -82,10 +82,4 @@ private_execution_after_timeout() {
   set -e
 }
 
-oneTimeTearDown() {
-  # remove docker with invalid configuration
-  docker_id=$(docker images -q "$jenkinsfile_runner_invalid_tag")
-  docker rmi -f "$docker_id"
-}
-
 init_framework


### PR DESCRIPTION
In #71 I added some tests to check negative scenarios. One of them is testing a wrong plugin configuration (`test_plugin_versions_collision`), so after the full execution I tried to delete the generated docker image in the `oneTimeTearDown` function. It cannot be done in the CI because if there are more processes on execution making use of this image, the `oneTimeTearDown` function fails. Let's remove it.

The error log we get:
```
Error response from daemon: conflict: unable to delete 48dd0ab99acc (cannot be forced) - image is being used by running container f9b448838c51

ASSERT:Unknown failure encountered running a test
```
The failing function:
```
oneTimeTearDown() {
  # remove docker with invalid configuration
  docker_id=$(docker images -q "$jenkinsfile_runner_invalid_tag")
  docker rmi -f "$docker_id"
}
```