### PR TITLE
Expand information about the joint use of JFR, CWP and Dependabot

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -80,4 +80,12 @@ The default directory is `/build` as well but it can be overridden using the `--
 A special case worth mentioning is the joint use of Custom War Packager and [Dependabot](https://dependabot.com) to maintain your docker image up to date.
 Custom War Packager offers the capability to [generate the Jenkinsfile Runner docker image through a pom file](https://github.com/jenkinsci/custom-war-packager/tree/master/demo/artifact-manager-s3-pom).
 Setting the plugins as dependencies and configuring Dependabot to scan that pom.xml will keep the plugins for the image updated to their latest versions.
-Both the [ci.jenkins.io-runner repository](https://github.com/jenkinsci/ci.jenkins.io-runner) and this very one repository has [Dependabot configured]](.dependabot), so they could be used as reference.
+The [ci.jenkins.io-runner repository](https://github.com/jenkinsci/ci.jenkins.io-runner) can be used as reference:
+
+* The ci.jenkins.io-runner repository makes use of Custom War Packager to build its own docker image.
+See the [Makefile](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/Makefile#L39-L42).
+* The [packager-config.yml](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/packager-config.yml#L7-L9) file configures the build settings so the `dependencies` section from the pom file in the repository is used as source of the list of plugins to install in the Jenkinsfile Runner image that will be built and run later.
+* Dependabot is configured to scan all the dependencies in pom.xml and Dockerfile files so it will open one pull request per each dependency susceptible to be updated.
+
+This very one repository has Dependabot configured as well and it could be used as another reference.
+See [.dependabot](.dependabot) folder for further details.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -83,8 +83,8 @@ Setting the plugins as dependencies and configuring Dependabot to scan that pom.
 The [ci.jenkins.io-runner project](https://github.com/jenkinsci/ci.jenkins.io-runner) can be used as reference:
 
 * The ci.jenkins.io-runner project makes use of Custom War Packager to build its own Jenkinsfile Runner image.
-See the [Makefile](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/Makefile#L39-L42).
-* The [packager-config.yml](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/packager-config.yml#L7-L9) file configures the build settings so that the list of plugins to install in the Jenkinsfile Runner image is gathered from the`dependencies` section in the pom file in the repository.
+See the [Makefile](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/66c959ca68aa3379d8eb2bdae39c884adf1fe908/Makefile#L39-L42).
+* The [packager-config.yml](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/eb571f5594708c3fbad167032326765257398354/packager-config.yml#L7-L9) file configures the build settings so that the list of plugins to install in the Jenkinsfile Runner image is gathered from the`dependencies` section in the pom file in the repository.
 * Dependabot is configured to scan all the dependencies in pom.xml and Dockerfile files so it will open one pull request per each dependency susceptible to be updated.
 
 This very one repository has Dependabot configured as well and it could be used as another reference.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -80,11 +80,11 @@ The default directory is `/build` as well but it can be overridden using the `--
 A special case worth mentioning is the joint use of Custom War Packager and [Dependabot](https://dependabot.com) to maintain your docker image up to date.
 Custom War Packager offers the capability to [generate the Jenkinsfile Runner docker image through a pom file](https://github.com/jenkinsci/custom-war-packager/tree/master/demo/artifact-manager-s3-pom).
 Setting the plugins as dependencies and configuring Dependabot to scan that pom.xml will keep the plugins for the image updated to their latest versions.
-The [ci.jenkins.io-runner repository](https://github.com/jenkinsci/ci.jenkins.io-runner) can be used as reference:
+The [ci.jenkins.io-runner project](https://github.com/jenkinsci/ci.jenkins.io-runner) can be used as reference:
 
-* The ci.jenkins.io-runner repository makes use of Custom War Packager to build its own docker image.
+* The ci.jenkins.io-runner project makes use of Custom War Packager to build its own Jenkinsfile Runner image.
 See the [Makefile](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/Makefile#L39-L42).
-* The [packager-config.yml](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/packager-config.yml#L7-L9) file configures the build settings so the `dependencies` section from the pom file in the repository is used as source of the list of plugins to install in the Jenkinsfile Runner image that will be built and run later.
+* The [packager-config.yml](https://github.com/jenkinsci/ci.jenkins.io-runner/blob/master/packager-config.yml#L7-L9) file configures the build settings so that the list of plugins to install in the Jenkinsfile Runner image is gathered from the`dependencies` section in the pom file in the repository.
 * Dependabot is configured to scan all the dependencies in pom.xml and Dockerfile files so it will open one pull request per each dependency susceptible to be updated.
 
 This very one repository has Dependabot configured as well and it could be used as another reference.


### PR DESCRIPTION
One of the use cases worth mentioning is the joint use of Custom War Packager and Dependabot. The [ci.jenkins.io-runner repository](https://github.com/jenkinsci/ci.jenkins.io-runner) can be use as reference and example of one success case of the this joint use, so with this PR I'm extending and clarifying the documentation.