### PR TITLE
Introduced --runHome to specify the runs JENKINS_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,12 @@ Advanced options:
 * In the Vanilla `Dockerfile` the master workspace is mapped to `/build`.
   This directory can be exposed as a volume.
   The docker image generated with Custom War Packager maps the workspace to `/build` by default and it can be exposed as well.
-  However it is possible to override that directory if both the `-v` docker option and the `--runworkspace` Jenkinsfile Runner option are specified.
+  However it is possible to override that directory if both the `-v` docker option and the `--runWorkspace` Jenkinsfile Runner option are specified.
+* By default the JENKINS_HOME folder is randomly created and disposed afterwards. With the `--runHome` parameter in combination with the `-v` docker option it is possible to specify a folder.   
+  e.g. `docker run -v /local/Jenkinsfile:/workspace/Jenkinsfile -v /local/jenkinsHome:/jenkinsHome ${JENKINSFILE_RUNNER_IMAGE} --runHome /jenkinsHome`
+
+  This way you can access the build metadata in `<jenkinsHome>/jobs/job/builds/1`, like the build.xml, logs, and workflow data, even after the container finished.
+
 * The `-ns` and `-a` options can be specified and passed to the image in the same way as the command line execution.
 
 ## Docker build

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
 
 ```
  # Usage: jenkinsfile-runner -w [warPath] -p [pluginsDirPath] -f [jenkinsfilePath] [other options]
+ --runHome FILE          : Path to the empty Jenkins Home directory to use for
+                           this run. If not specified a temporary directory
+                           will be created. Note that the folder specified via
+                           --runHome will not be disposed after the run.
  --runWorkspace FILE     : Path to the workspace of the run to be used within
                            the node{} context. It applies to both Jenkins
                            master and agents (or side containers) if any.
@@ -118,10 +122,11 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
  -p (--plugins) FILE     : plugins required to run pipeline. Either a
                            plugins.txt file or a /plugins installation
                            directory. Defaults to plugins.txt.
- -v (--version) VAL      : jenkins version to use (only in case 'warDir' is not specified). Defaults to latest LTS.
- -w (--jenkins-war) FILE : path to exploded jenkins war directory
+ -v (--version) VAL      : jenkins version to use (only in case 'warDir' is not
+                           specified). Defaults to latest LTS.
+ -w (--jenkins-war) FILE : path to exploded jenkins war directory.
 
-where `-a`, `-ns`, `--runWorkspace` and `-v` are optional.
+where `-a`, `-ns`, `--runHome`, `--runWorkspace` and `-v` are optional.
 ```
 
 ###  Passing parameters

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -64,6 +64,14 @@ public class Bootstrap {
             "Requires Jenkins 2.119 or above")
     public File runWorkspace;
 
+    /**
+     * Jenkins Home for the Run.
+     */
+    @CheckForNull
+    @Option(name = "--runHome", usage = "Path to the empty Jenkins Home directory to use for this run. If not specified a temporary directory will be created. " +
+            "Note that the folder specified via --runHome will not be disposed after the run.")
+    public File runHome;
+
 
     @Option(name = "-a", aliases = { "--arg" }, usage = "Parameters to be passed to workflow job. Use multiple -a switches for multiple params")
     @CheckForNull

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerLauncher.java
@@ -4,6 +4,7 @@ import hudson.ClassicPluginStrategy;
 import hudson.security.ACL;
 import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
 import io.jenkins.jenkinsfile.runner.bootstrap.ClassLoaderBuilder;
+import io.jenkins.jenkinsfile.runner.util.HudsonHomeLoader;
 import jenkins.slaves.DeprecatedAgentProtocolMonitor;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
@@ -34,6 +35,12 @@ public class JenkinsfileRunnerLauncher extends JenkinsEmbedder {
 
     public JenkinsfileRunnerLauncher(Bootstrap bootstrap) {
         this.bootstrap = bootstrap;
+        if(bootstrap.runHome != null) {
+            if(!bootstrap.runHome.isDirectory()) throw new IllegalArgumentException("--runHome is not a directory: " + bootstrap.runHome.getAbsolutePath());
+            if(bootstrap.runHome.list().length > 0) throw new IllegalArgumentException("--runHome directory is not empty: " + bootstrap.runHome.getAbsolutePath());
+            //Override homeLoader to use existing directory instead of creating temporary one
+            this.homeLoader = new HudsonHomeLoader.UseExisting(bootstrap.runHome);
+        }
     }
 
     /**

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/util/HudsonHomeLoader.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/util/HudsonHomeLoader.java
@@ -105,6 +105,22 @@ public interface HudsonHomeLoader {
     }
 
     /**
+     * Does not allocate a new directory but uses the specified one.
+     * Since TemporaryDirectoryAllocator is not used this folder will not be affected by the dispose() at the end.
+     */
+    final class UseExisting implements HudsonHomeLoader {
+        private final File source;
+
+        public UseExisting(File source) {
+            this.source = source;
+        }
+
+        public File allocate() throws Exception {
+            return source;
+        }
+    }
+
+    /**
      * Allocates a new directory by copying from a test resource
      */
     final class Local implements HudsonHomeLoader {


### PR DESCRIPTION
We are going to use the Jenkinsfile Runner in Docker to run ephemeral pipelines. In order to copy the status of the pipeline (final result, steps graph, logs,...), before the container vanishes, it would be easier to have a defined location (inside the container) for the used Jenkins home. And it is required to keep this folder after Jenkinsfile Runner finished (the folder will be gone anyway once the Docker container finished).

Currently the temp folder is created randomly and disposed after the run (e.g. `/tmp/jenkinsfileRunner.tmp/jfr67075404322545838.run`).

This pull request introduces a `--runHome` parameter.
> --runHome
> Path to the empty Jenkins Home directory to use for this run. If not specified a temporary directory will be created. Note that the folder specified via --runHome will not be disposed after the run.


## Side note

Is it the right approach to use/copy the files from `JENKINS_HOME/jobs/job/builds/1` or is there a better way to get all this information once the Jenkinsfile Runner finished?

Thanks and best regards,
Alex