### PR TITLE
Update jenkins core to 2.164.2, and update to recent plugins and libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG JENKINS_VERSION=2.164.1
+ARG JENKINS_VERSION=2.164.2
 
 # Define maven version for other stages
-FROM maven:3.5.2 as maven
+FROM maven:3.5.4 as maven
 
 FROM maven as jenkinsfilerunner-mvncache
 ADD pom.xml /src/pom.xml

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -13,12 +13,11 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.0.31</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -25,27 +25,27 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.41</version>
+      <version>2.67</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.26</version>
+      <version>2.33</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.17</version>
+      <version>2.32</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
-      <version>2.9.2</version>
+      <version>2.21</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.6</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -56,22 +56,27 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.3</version>
+      <version>2.15</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.9</version>
+      <version>2.30</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>2.17</version>
+      <version>3.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.39</version>
+      <version>1.58</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.4.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/payload/pom.xml
+++ b/payload/pom.xml
@@ -20,5 +20,9 @@
       <artifactId>setup</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.39</version>
+    <version>1.51</version>
     <relativePath />
   </parent>
 
@@ -60,8 +60,10 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
-    <jenkins.version>2.89</jenkins.version>
-    <jetty.version>9.4.5.v20170502</jetty.version>
+    <jenkins.version>2.164.2</jenkins.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
+    <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
+    <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
   <dependencyManagement>
@@ -85,12 +87,17 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>symbol-annotation</artifactId>
-        <version>1.7</version>
+        <version>1.17</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>annotation-indexer</artifactId>
         <version>1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>args4j</groupId>
+        <artifactId>args4j</artifactId>
+        <version>2.33</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
I am tired of a bunch of Dependabot update requests which cannot be really satisfied due old versions of plugins bundled into JFR.  This pull requests just updates everything to the recent versions, a number of fixes is included (e.g. Java 11 compatibility in plugins)