### PR TITLE
JENKINS-57441 workaround + demo update

### DIFF
--- a/demo/cwp/packager-config.yml
+++ b/demo/cwp/packager-config.yml
@@ -14,35 +14,35 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.150.2"
+      base: "jenkins/jenkins:2.164.2"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.150.2"
+    version: "2.164.2"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
     source:
-      version: "2.24"
+      version: "2.32"
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: "2.48"
+      version: "2.67"
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-api"
     source:
-      version: "2.27"
+      version: "2.33"
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-step-api"
     source:
-      version: "2.14"
+      version: "2.19"
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-utility-steps"
     source:
-      version: "2.1.0"
+      version: "2.3.0"
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cloudbees-folder"
     source:
@@ -54,7 +54,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "structs"
     source:
-      version: "1.14"
+      version: "1.17"
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "scm-api"
     source:

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
     <jenkins.version>2.164.2</jenkins.version>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.4.5.v20170502</jetty.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>


### PR DESCRIPTION
The patch updates the standard Jenkinsfile Runner demo (versions are now aligned with the vanilla baseline) and also applies a workaround for https://issues.jenkins-ci.org/browse/JENKINS-57441