### PR TITLE
Add missing dep so mvn package completes without error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@ THE SOFTWARE.
       <artifactId>annotations</artifactId>
       <version>3.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Add the following to the dependencies.
```
    <dependency>
      <groupId>javax.annotation</groupId>
      <artifactId>javax.annotation-api</artifactId>
      <version>1.2</version>
    </dependency>
```  
