### PR TITLE
Use Jenkins BOM to specify plugin versions + Update to 2.176.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG JENKINS_VERSION=2.176.1
+ARG JENKINS_VERSION=2.176.2
 
 # Define maven version for other stages
 FROM maven:3.5.4 as maven

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,7 +1,7 @@
 # Build the docker image using the local build in developer box
 # To avoid downloading everything from the internet and using developer's cache
 
-ARG JENKINS_VERSION=2.176.1
+ARG JENKINS_VERSION=2.176.2
 
 FROM jenkins/jenkins:${JENKINS_VERSION} as jenkins
 USER root

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
     </dependency>
   </dependencies>
 </project>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -25,58 +25,47 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.67</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.33</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.32</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
-      <version>2.21</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>2.4</version>
       <classifier>tests</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.15</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.30</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>3.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.58</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.4.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
-    <jenkins.version>2.164.3</jenkins.version>
+    <jenkins.version>2.176.2</jenkins.version>
     <jetty.version>9.4.5.v20170502</jetty.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <findbugs.failOnError>false</findbugs.failOnError>
@@ -68,6 +68,13 @@ THE SOFTWARE.
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom</artifactId>
+        <version>${jenkins.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
@@ -83,12 +90,6 @@ THE SOFTWARE.
         <artifactId>slf4j-jdk14</artifactId>
         <version>1.7.25</version>
       </dependency>
-      <!-- Annotation engine which we want to keep at recent versions instead of ones bundled in the core -->
-      <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>symbol-annotation</artifactId>
-        <version>1.17</version>
-      </dependency>
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>annotation-indexer</artifactId>
@@ -98,6 +99,25 @@ THE SOFTWARE.
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
         <version>2.33</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.6</version>
+      </dependency>
+
+      <!--TODO(oleg-nenashev): Remove once in BOM -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-multibranch</artifactId>
+        <version>2.21</version>
+      </dependency>
+      <!--TODO(oleg-nenashev): Is it a valid use-case? Move to BOM if so -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-scm-step</artifactId>
+        <classifier>tests</classifier>
+        <version>2.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom</artifactId>
+        <!--WARNING: it is not a Jenkins core version. https://issues.jenkins-ci.org/browse/JENKINS-58770 -->
         <version>2.176.2</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom</artifactId>
-        <version>${jenkins.version}</version>
+        <version>2.176.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
It should help a lot to manage the Pipeline dependencies in the project. Dependabot definitely struggles with that, so it should help a lot.

FTR https://github.com/jenkinsci/bom
