### PR TITLE
Remove the Pipeline Step API test dependency

### DIFF
--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -44,11 +44,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-scm-step</artifactId>
-      <classifier>tests</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,6 @@ THE SOFTWARE.
         <artifactId>workflow-multibranch</artifactId>
         <version>2.21</version>
       </dependency>
-      <!--TODO(oleg-nenashev): Is it a valid use-case? Move to BOM if so -->
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-scm-step</artifactId>
-        <classifier>tests</classifier>
-        <version>2.4</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Follow-up to #143 . Theoretically, it is no longer used