### PR TITLE
#165 - Prevent pipeline parameters from being null

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -153,6 +153,11 @@ public class Bootstrap {
         if (this.workflowParameters == null){
             this.workflowParameters = new HashMap<>();
         }
+        for (Map.Entry<String, String> workflowParameter : this.workflowParameters.entrySet()) {
+            if (workflowParameter.getValue() == null) {
+                workflowParameter.setValue("");
+            }
+        }
     }
 
     private File getJenkinsWar() throws IOException {


### PR DESCRIPTION
Pipeline job parameters with `null` value may break pipelines that run
successfully in a classical Jenkins, for instance:

```
java.lang.IllegalArgumentException: Null value not allowed as an environment variable: PARAM1
    at hudson.EnvVars.put(EnvVars.java:378)
    at hudson.model.StringParameterValue.buildEnvironment(StringParameterValue.java:59)
    at hudson.model.ParametersAction.buildEnvironment(ParametersAction.java:145)
    at hudson.model.Run.getEnvironment(Run.java:2383)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.getEnvironment(WorkflowRun.java:471)
    ...
```

Use zero-length string values instead of `null` like it's done for
parametrized pipeline jobs in a classical Jenkins.