### PR TITLE
#180 - Modify -v/--version flag to display the version + Use `-jv/--jenkinsVersion` for the former behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,28 +107,28 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
 
 ```
  # Usage: jenkinsfile-runner -w [warPath] -p [pluginsDirPath] -f [jenkinsfilePath] [other options]
- --runHome FILE          : Path to the empty Jenkins Home directory to use for
-                           this run. If not specified a temporary directory
-                           will be created. Note that the folder specified via
-                           --runHome will not be disposed after the run.
- --runWorkspace FILE     : Path to the workspace of the run to be used within
-                           the node{} context. It applies to both Jenkins
-                           master and agents (or side containers) if any.
-                           Requires Jenkins 2.119 or above
- -a (--arg)              : Parameters to be passed to workflow job. Use
-                           multiple -a switches for multiple params
- -f (--file) FILE        : Path to Jenkinsfile (or directory containing a
-                           Jenkinsfile) to run, default to ./Jenkinsfile.
- -ns (--no-sandbox)      : Disable workflow job execution within sandbox
-                           environment
- -p (--plugins) FILE     : plugins required to run pipeline. Either a
-                           plugins.txt file or a /plugins installation
-                           directory. Defaults to plugins.txt.
- -v (--version) VAL      : jenkins version to use (only in case 'warDir' is not
-                           specified). Defaults to latest LTS.
- -w (--jenkins-war) FILE : path to exploded jenkins war directory.
+ --runHome FILE              : Path to the empty Jenkins Home directory to use for
+                               this run. If not specified a temporary directory
+                               will be created. Note that the folder specified via
+                               --runHome will not be disposed after the run.
+ --runWorkspace FILE         : Path to the workspace of the run to be used within
+                               the node{} context. It applies to both Jenkins
+                               master and agents (or side containers) if any.
+                               Requires Jenkins 2.119 or above
+ -a (--arg)                  : Parameters to be passed to workflow job. Use
+                               multiple -a switches for multiple params
+ -f (--file) FILE            : Path to Jenkinsfile (or directory containing a
+                               Jenkinsfile) to run, default to ./Jenkinsfile.
+ -ns (--no-sandbox)          : Disable workflow job execution within sandbox
+                               environment
+ -p (--plugins) FILE         : plugins required to run pipeline. Either a
+                               plugins.txt file or a /plugins installation
+                               directory. Defaults to plugins.txt.
+ -jv (--jenkins-version) VAL : jenkins version to use (only in case 'warDir' is not
+                               specified). Defaults to latest LTS.
+ -w (--jenkins-war) FILE     : path to exploded jenkins war directory.
 
-where `-a`, `-ns`, `--runHome`, `--runWorkspace` and `-v` are optional.
+where `-a`, `-ns`, `--runHome`, `--runWorkspace` and `-jv` are optional.
 ```
 
 ###  Passing parameters

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
                                specified). Defaults to latest LTS.
  -w (--jenkins-war) FILE     : path to exploded jenkins war directory.
  -v (--version)              : Display the current version
+ -h (--help)                 : Print this help
 
 where `-a`, `-ns`, `--runHome`, `--runWorkspace` and `-jv` are optional.
 ```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
  -jv (--jenkins-version) VAL : jenkins version to use (only in case 'warDir' is not
                                specified). Defaults to latest LTS.
  -w (--jenkins-war) FILE     : path to exploded jenkins war directory.
+ -v (--version)              : Display the current version
 
 where `-a`, `-ns`, `--runHome`, `--runWorkspace` and `-jv` are optional.
 ```

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -44,7 +44,8 @@ public class Bootstrap {
     public File warDir;
 
     @Option(name = "-jv", aliases = { "--jenkins-version"}, usage = "jenkins version to use (only in case 'warDir' is not specified). Defaults to latest LTS.")
-
+    public String version;
+    
     /**
      * Where to load plugins from?
      */

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -9,6 +9,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URL;
@@ -18,6 +19,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -28,8 +30,6 @@ public class Bootstrap {
 
     public static final long CACHE_EXPIRE = System.currentTimeMillis() - 24 * 3600 * 1000;
     private static final String WORKSPACES_DIR_SYSTEM_PROPERTY = "jenkins.model.Jenkins.workspacesDir";
-
-    private static final String VERSION = "1.0-beta-10-SNAPSHOT";
 
     /**
      * This system property is set by the bootstrap script created by appassembler Maven plugin
@@ -114,7 +114,7 @@ public class Bootstrap {
     private void postConstruct() throws IOException {
 
         if (showVersion) {
-            System.out.println(VERSION);
+            System.out.println(getVersion());
             System.exit(0);
         }
 
@@ -167,6 +167,15 @@ public class Bootstrap {
             if (workflowParameter.getValue() == null) {
                 workflowParameter.setValue("");
             }
+        }
+    }
+
+    private String getVersion() throws IOException {
+        String propertiesPath = "/META-INF/maven/io.jenkins.jenkinsfile-runner/jenkinsfile-runner/pom.properties";
+        try (InputStream pomProperties = this.getClass().getResourceAsStream(propertiesPath)) {
+            Properties props = new Properties();
+            props.load(pomProperties);
+            return props.getProperty("version");
         }
     }
 

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -29,6 +29,8 @@ public class Bootstrap {
     public static final long CACHE_EXPIRE = System.currentTimeMillis() - 24 * 3600 * 1000;
     private static final String WORKSPACES_DIR_SYSTEM_PROPERTY = "jenkins.model.Jenkins.workspacesDir";
 
+    private static final String VERSION = "1.0-beta-10-SNAPSHOT";
+
     /**
      * This system property is set by the bootstrap script created by appassembler Maven plugin
      * to point to a local Maven repository.
@@ -80,6 +82,9 @@ public class Bootstrap {
     @Option(name = "-ns", aliases = { "--no-sandbox" }, usage = "Disable workflow job execution within sandbox environment")
     public boolean noSandBox;
 
+    @Option(name = "-v", aliases = { "--version" }, usage = "Prints the current Jenkinsfile Runner version")
+    public boolean showVersion;
+
     public static void main(String[] args) throws Throwable {
         // break for attaching profiler
         if (Boolean.getBoolean("start.pause")) {
@@ -107,6 +112,11 @@ public class Bootstrap {
 
     @PostConstruct
     private void postConstruct() throws IOException {
+
+        if (showVersion) {
+            System.out.println(VERSION);
+            System.exit(0);
+        }
 
         if (warDir == null) {
             warDir= getJenkinsWar();

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -38,10 +38,10 @@ public class Bootstrap {
     /**
      * Exploded jenkins.war
      */
-    @Option(name = "-w", aliases = { "--jenkins-war" }, usage = "path to exploded jenkins war directory.", forbids = { "-v" })
+    @Option(name = "-w", aliases = { "--jenkins-war" }, usage = "path to exploded jenkins war directory.", forbids = { "-jv" })
     public File warDir;
 
-    @Option(name = "-v", aliases = { "--version"}, usage = "jenkins version to use (only in case 'warDir' is not specified). Defaults to latest LTS.")
+    @Option(name = "-jv", aliases = { "--jenkins-version"}, usage = "jenkins version to use (only in case 'warDir' is not specified). Defaults to latest LTS.")
     public String version;
     /**
      * Where to load plugins from?


### PR DESCRIPTION
This PR changes the functionality of the previous -v/--version flag (which is now called -jv/--jenkins-version) to display the version of the jenkinsfile-runner.

A few notes:

 - I hope I got all correct occurences of the "old" -v flag in the readme
 - I did *not* change version yet as this is a breaking change and did not want to change the wrong things
 - I added a new variable for the version which would be hardcoded and would have to be changed. I couldn't find any config file and parsing the pom.xml surely is not the way to go :P If there is a proper place where I would get the version number from otherwise, I will gladly change the code to do so.