### PR TITLE
#185, #175 - Manage Vanilla package jenkins.war and plugins through a Maven module to prevent startup failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ tests/.settings/
 tests/*.log
 demo/cwp-jdk11/out/
 demo/cwp-jdk11/source/
+vanilla-package/.classpath
+vanilla-package/.factorypath
+vanilla-package/target/

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -52,6 +52,10 @@ execution engine, configuring the classloader properly.
 It also contains classes to implement or configure this "environment", such as a custom implementation for the Plugin Manager
 or a WAR exploder in charge of exploding the WAR file and fully initialising an instance.
 
+## `vanilla-package` module
+
+Defines the dependencies to be included into the Vanilla Docker distribution.
+
 ## `tests` module
 
 Contains the integration tests powered by the [Jenkinsfile Runner Test Framework](https://github.com/jenkinsci/jenkinsfile-runner-test-framework).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG JENKINS_VERSION=2.176.2
-
 # Define maven version for other stages
 FROM maven:3.5.4 as maven
 
@@ -11,6 +9,7 @@ ADD setup/pom.xml /src/setup/pom.xml
 ADD payload/pom.xml /src/payload/pom.xml
 ADD payload-dependencies/pom.xml /src/payload-dependencies/pom.xml
 ADD tests/pom.xml /src/tests/pom.xml
+ADD vanilla-package/pom.xml /src/vanilla-package/pom.xml
 
 WORKDIR /src
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
@@ -21,23 +20,16 @@ ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD . /jenkinsfile-runner
 RUN cd /jenkinsfile-runner && mvn package
-
-FROM jenkins/jenkins:${JENKINS_VERSION} as jenkins
-USER root
-# Delete big files not needed
-RUN mkdir /app && unzip /usr/share/jenkins/jenkins.war -d /app/jenkins && \
+RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
 
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
 USER root
 RUN mkdir -p /app /usr/share/jenkins/ref/plugins
-COPY --from=jenkins /app/jenkins /app/jenkins
-COPY --from=jenkins /usr/local/bin/install-plugins.sh /usr/local/bin/install-plugins.sh
-COPY --from=jenkins /usr/local/bin/jenkins-support /usr/local/bin/jenkins-support
-COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app
+COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
 COPY jenkinsfile-runner-launcher /app/bin
 
 VOLUME /build

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,24 +1,16 @@
 # Build the docker image using the local build in developer box
 # To avoid downloading everything from the internet and using developer's cache
 
-ARG JENKINS_VERSION=2.176.2
-
-FROM jenkins/jenkins:${JENKINS_VERSION} as jenkins
-USER root
-# Delete big files not needed
-RUN mkdir /app && unzip /usr/share/jenkins/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
-
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
 USER root
 RUN mkdir -p /app /usr/share/jenkins/ref/plugins
-COPY --from=jenkins /app/jenkins /app/jenkins
-COPY --from=jenkins /usr/local/bin/install-plugins.sh /usr/local/bin/install-plugins.sh
-COPY --from=jenkins /usr/local/bin/jenkins-support /usr/local/bin/jenkins-support
-COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+
 COPY app/target/appassembler /app
+COPY vanilla-package/target/war/jenkins.war /usr/share/jenkins/jenkins.war
+RUN unzip /usr/share/jenkins/jenkins.war -d /app/jenkins && \
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
+COPY vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner", \
             "-w", "/app/jenkins",\

--- a/demo/declarative-pipeline/Jenkinsfile
+++ b/demo/declarative-pipeline/Jenkinsfile
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+    parameters {
+        string(name: 'param1', defaultValue: '', description: 'Greeting message')
+        string(name: 'param2', defaultValue: '', description: '2nd parameter')
+    }
+    stages {
+        stage('Build') {
+            steps {
+                echo 'Hello world!'
+                echo "message: ${params.param1}"
+                echo "param2: ${params.param2}"
+                sh 'ls -la'
+            }
+        }
+    }
+}

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,1 +1,0 @@
-pipeline-model-definition:latest

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@ THE SOFTWARE.
     <module>payload</module>
     <module>app</module>
     <module>tests</module>
+    <module>vanilla-package</module>
   </modules>
 
   <properties>
@@ -112,6 +113,12 @@ THE SOFTWARE.
         <artifactId>workflow-multibranch</artifactId>
         <version>2.21</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>3.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -129,7 +136,6 @@ THE SOFTWARE.
         <!-- to treat executable-war type of artifact correctly -->
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>3.5</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -15,7 +15,6 @@
         <!-- to treat executable-war type of artifact correctly -->
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>3.5</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -1,0 +1,122 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.jenkins.jenkinsfile-runner</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-beta-10-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>vanilla-package</artifactId>
+  <description>Defines plugins which should be included into the Vanilla bundle</description>
+
+  <dependencies>
+    <!-- All Payload dependencies are inherited here -->
+    <!-- TODO(oleg-nenashev): payload-dependencies is not HPI, and hpi:assemble-dependencies does not include plugins unless listed explicitly here
+         Would be nice to deduplicate
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+    </dependency>
+
+    <!-- Extra Dependencies for Vanilla -->
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <!--TODO: Use BOM? -->
+      <version>1.3.9</version>
+      <exclusions>
+        <!-- Upper bounds conflict with the Jenkins Core -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-plugins-dir</id>
+            <phase>package</phase>
+            <goals>
+              <goal>assemble-dependencies</goal>
+            </goals>
+            <configuration>
+              <minimumJavaVersion>8</minimumJavaVersion>
+              <jenkinsCoreVersionOverride>${jenkins.version}</jenkinsCoreVersionOverride>
+              <outputDirectory>${project.build.directory}/plugins</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-war</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.main</groupId>
+                  <artifactId>jenkins-war</artifactId>
+                  <version>${jenkins.version}</version>
+                  <type>war</type>
+                  <outputDirectory>${project.build.directory}/war</outputDirectory>
+                  <destFileName>jenkins.war</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Fixes #185 . Basically, Vanilla package was at constant risk of binary conflicts due to the obsolete core and plugins. This change makes everything managed by Maven, and hence we get Enforcer checks and proper Dependabot integration. 

Docker images are also more simple now, but they can be still extended like before.