### PR TITLE
Disable Docker image deployment from ci.jenkins.io due to the unstable CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,13 +110,14 @@ node('docker') {
                 }
             }
 
-            if (branchName.startsWith('master')) {
-                stage('Publish container') {
-                    timestamps {
-                        image.push();
-                    }
-                }
-            }
+  // TODO(oleg-nenashev): Reenable once CI is stable
+  //          if (branchName.startsWith('master')) {
+  //              stage('Publish container') {
+  //                  timestamps {
+  //                      image.push();
+  //                  }
+  //              }
+  //          }
         }
     }
 }


### PR DESCRIPTION
DockerHub will be used instead for now