### PR TITLE
Add Pipeline Utility Steps to the Vanilla Package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,13 @@ THE SOFTWARE.
         <artifactId>maven-hpi-plugin</artifactId>
         <version>3.5</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>pipeline-utility-steps</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/tests/test_resources/vanilla-images/test_declarative_pipeline/Jenkinsfile
+++ b/tests/test_resources/vanilla-images/test_declarative_pipeline/Jenkinsfile
@@ -12,5 +12,11 @@ pipeline {
                 echo "Value for param2: ${params.param2}"
             }
         }
+        stage('Use Pipeline Steps - Read Yaml ') {
+            steps {
+                def essentialsYaml = readYaml(file: "example.yaml")
+                echo "First param key: ${essentialsYaml.params[0].key}"
+            }
+        }
     }
 }

--- a/tests/test_resources/vanilla-images/test_declarative_pipeline/example.yaml
+++ b/tests/test_resources/vanilla-images/test_declarative_pipeline/example.yaml
@@ -1,0 +1,9 @@
+parameters:
+  params:
+    -
+    key: param1
+    value: 'Hello world'
+    -
+    key: param2
+    value: ''
+

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -55,6 +55,10 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-utility-steps</artifactId>
+    </dependency>
 
     <!-- Extra Dependencies for Vanilla -->
     <dependency>


### PR DESCRIPTION
- Extended dependency management in root-pom and vanilla-package pom with pipeline-utility-steps version 1.1.1 
- Extended a declarative pipeline test case for vanilla-package with a yamlReader use cases. However, I cannot get the integration tests running. Let us see what CI has to say ;)