### PR TITLE
#197 - Include Jenkins Configuration as Code plugin into the Vanilla Package

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -53,6 +53,11 @@ root@dec4c0f12478:/src# cp -r /app/jenkins /tmp/jenkins
 root@dec4c0f12478:/src# /app/bin/jenkinsfile-runner -w /tmp/jenkins -p /usr/share/jenkins/ref/plugins -f /workspace
 ```
 
+Optionally, if you need special Jenkins configuration, you can mount JCasC YAML files into the
+`/usr/share/jenkins/ref/casc` directory as a volume. Refer to the
+[Configuration-as-Code documentation](https://github.com/jenkinsci/configuration-as-code-plugin)
+for available options and the [JCasC demo](demo/casc/README.md) for an example.
+
 ## Debug
 In case you want to debug Jenkinsfile Runner, you need to use the "Vanilla" Docker image built following the steps mentioned in the section above.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,17 @@ RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.w
 
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
+ENV CASC_JENKINS_CONFIG file:///casc/jenkins.yaml
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /casc
+RUN echo "jenkins: {}" >/casc/jenkins.yaml
 COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
 COPY jenkinsfile-runner-launcher /app/bin
 
 VOLUME /build
+VOLUME /casc
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner-launcher", \
             "-w", "/app/jenkins",\

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,17 @@ RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.w
 
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
-ENV CASC_JENKINS_CONFIG file:///casc/jenkins.yaml
+ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins /casc
-RUN echo "jenkins: {}" >/casc/jenkins.yaml
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc
+RUN echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml
 COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
 COPY jenkinsfile-runner-launcher /app/bin
 
 VOLUME /build
-VOLUME /casc
+VOLUME /usr/share/jenkins/ref/casc
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner-launcher", \
             "-w", "/app/jenkins",\

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,14 +3,18 @@
 
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
+ENV CASC_JENKINS_CONFIG file:///casc/jenkins.yaml
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /casc
+RUN echo "jenkins: {}" >/casc/jenkins.yaml
 
 COPY app/target/appassembler /app
 COPY vanilla-package/target/war/jenkins.war /usr/share/jenkins/jenkins.war
 RUN unzip /usr/share/jenkins/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
 COPY vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
+
+VOLUME /casc
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner", \
             "-w", "/app/jenkins",\

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,10 +3,10 @@
 
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
-ENV CASC_JENKINS_CONFIG file:///casc/jenkins.yaml
+ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins /casc
-RUN echo "jenkins: {}" >/casc/jenkins.yaml
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc
+RUN echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml
 
 COPY app/target/appassembler /app
 COPY vanilla-package/target/war/jenkins.war /usr/share/jenkins/jenkins.war
@@ -14,7 +14,7 @@ RUN unzip /usr/share/jenkins/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
 COPY vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
 
-VOLUME /casc
+VOLUME /usr/share/jenkins/ref/casc
 
 ENTRYPOINT ["/app/bin/jenkinsfile-runner", \
             "-w", "/app/jenkins",\

--- a/demo/casc/Jenkinsfile
+++ b/demo/casc/Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                echo 'Hello world!'
+                echo "An environment variable configured via JCasC: ${env.SOME_CASC_ENV_VAR}"
+            }
+        }
+    }
+}

--- a/demo/casc/README.md
+++ b/demo/casc/README.md
@@ -1,0 +1,35 @@
+CasC Demo
+=========
+This directory contains resources demonstrating the use of
+[Configuration-as-Code](https://github.com/jenkinsci/configuration-as-code-plugin)
+with jenkinsfile-runner.
+
+The provided `Jenkinsfile` reads an environment variable that is defined via
+JCasC in `config/jenkins.yaml`. The `config` directory is mounted in the
+Docker image to `/usr/share/jenkins/ref/casc`, where it is recognized by
+Jenkins. Note that this does not need to be a single file, but can be
+split up into multiple YAMLs.
+
+Running the demo
+----------------
+The following commands need to be run in the directory containing this file.
+
+If you have not built the Docker image yet:
+(Refer to the [Packaging to Docker image](../../DOCKER.md) page for details on the
+Docker packaging process)
+````bash
+docker build -t jenkinsfile-runner:my-production-jenkins ../..
+````
+
+Now that the image is built, run it, mounting the `config` directory:
+````bash
+docker run --rm -v $PWD:/workspace -v $PWD/config:/usr/share/jenkins/ref/casc jenkinsfile-runner:my-production-jenkins
+````
+
+This will print the variable that was set via JCasC.
+````
+...
+[Pipeline] echo
+An environment variable configured via JCasC: a value configured via JCasC
+...
+````

--- a/demo/casc/config/jenkins.yaml
+++ b/demo/casc/config/jenkins.yaml
@@ -1,0 +1,6 @@
+jenkins:
+  globalNodeProperties:
+    - envVars:
+        env:
+          - key: SOME_CASC_ENV_VAR
+            value: a value configured via JCasc

--- a/demo/casc/config/jenkins.yaml
+++ b/demo/casc/config/jenkins.yaml
@@ -3,4 +3,4 @@ jenkins:
     - envVars:
         env:
           - key: SOME_CASC_ENV_VAR
-            value: a value configured via JCasc
+            value: a value configured via JCasC

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,13 @@ THE SOFTWARE.
         <artifactId>pipeline-utility-steps</artifactId>
         <version>2.3.1</version>
       </dependency>
+
+      <!-- TODO: Remove version override once BOM is updated to reference >=1.32 -->
+      <dependency>
+        <groupId>io.jenkins</groupId>
+        <artifactId>configuration-as-code</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>script-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
     </dependency>


### PR DESCRIPTION
### Ellipsis
This PR adds out-of-the-box support for configuration-as-code to configure the Jenkins instance the Vanilla Docker image runs the Jenkinsfile on. A volume is declared so that users may provide their own configuration file(s).
### Technical overview
This PR adds the JCasC plugin as a dependency to the vanilla module, installing it in the Jenkins running in the Docker image. It also adds configuration (via env) to `Dockerfile` so that the configuration is correctly picked up.
### Remaining challenges
- [x] (1) directory name support of JCasC isn't working on my machine. It tries to open a URL connection to the directory, which (for whatever reason) results in a stream of the file names in that directory separated by spaces. This is not valid YAML and causes the parser to throw. The `file://` URL is necessary because the implementation refuses strings that are not URLs. Seems like an issue in JCasC though. If this is a blocker for this PR, I'll try to reproduce it on a normal Jenkins instance. (Should work according to the docs) - please clarify whether we need that
- [x] (2) the empty `jenkins.yaml` provided in `Dockerfile-dev` (needs to be copies to `Dockerfile` as well) results in a warning from JCasC that it's empty. We might want to fill this with a file containing `jenkins:` or provide a reasonable default - I'll implement the first one hopefully tonight and expand it to a full default if necessary (although what would we want to configure? I saw the JDK is configured in code, so maybe that, but that would break non-Docker runs)
- [x] (3) the demo might need expansion - please provide feedback on whether this demo is sufficient
- [x] (4) docs - I'll add these hopefully tonight

@oleg-nenashev ref: #197 