### PR TITLE
Add an interactive CLI mode (--cli argument)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -58,6 +58,9 @@ Optionally, if you need special Jenkins configuration, you can mount JCasC YAML 
 [Configuration-as-Code documentation](https://github.com/jenkinsci/configuration-as-code-plugin)
 for available options and the [JCasC demo](demo/casc/README.md) for an example.
 
+To get an interactive Jenkins CLI shell in the container, pass
+`-i -e FORCE_JENKINS_CLI=true` to `docker run` as extra parameters.
+
 ## Debug
 In case you want to debug Jenkinsfile Runner, you need to use the "Vanilla" Docker image built following the steps mentioned in the section above.
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
                                Requires Jenkins 2.119 or above
  -a (--arg)                  : Parameters to be passed to workflow job. Use
                                multiple -a switches for multiple params
+ --cli                       : Launch interactive CLI. (default: false)
  -u (--keep-undefined-parameters) : Keep undefined parameters if set, defaults
                                     to false.
- -f (--file) FILE            : Path to Jenkinsfile (or directory containing a
+-f (--file) FILE            : Path to Jenkinsfile (or directory containing a
                                Jenkinsfile) to run, default to ./Jenkinsfile.
  -ns (--no-sandbox)          : Disable workflow job execution within sandbox
                                environment
@@ -181,6 +182,8 @@ Advanced options:
   This way you can access the build metadata in `<jenkinsHome>/jobs/job/builds/1`, like the build.xml, logs, and workflow data, even after the container finished.
 
 * The `-ns` and `-a` options can be specified and passed to the image in the same way as the command line execution.
+
+* You may pass `--cli` to obtain an interactive Jenkins CLI session.
 
 ## Docker build
 

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -70,7 +70,7 @@ public class Bootstrap {
             "Note that the folder specified via --runHome will not be disposed after the run.")
     public File runHome;
 
-    
+
     private static final String DEFAULT_JOBNAME = "job";
 
     /**
@@ -107,6 +107,8 @@ public class Bootstrap {
     @Option(name = "-u", aliases = { "--keep-undefined-parameters"}, usage = "Keep undefined parameters if set")
     public boolean keepUndefinedParameters = false;
 
+    @Option(name = "--cli", usage = "Launch interactive CLI.", forbids = { "-v", "--runWorkspace", "-a", "-ns" })
+    public boolean cliOnly;
 
     public static void main(String[] args) throws Throwable {
         // break for attaching profiler
@@ -141,6 +143,10 @@ public class Bootstrap {
             System.exit(0);
         }
 
+        if (System.getenv("FORCE_JENKINS_CLI") != null) {
+            this.cliOnly = true;
+        }
+
         if (this.version != null && !isVersionSupported()) {
             System.err.printf("Jenkins version [%s] not suported by this jenkinsfile-runner version (requires %s). \n",
                     this.version,
@@ -159,7 +165,7 @@ public class Bootstrap {
         }
 
         if (this.jenkinsfile == null) this.jenkinsfile = new File("Jenkinsfile");
-        if (!this.jenkinsfile.exists()) {
+        if (!this.cliOnly && !this.jenkinsfile.exists()) {
             System.err.println("no Jenkinsfile in current directory.");
             System.exit(-1);
         }

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/App.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/App.java
@@ -9,8 +9,15 @@ import io.jenkins.jenkinsfile.runner.bootstrap.IApp;
 public class App implements IApp {
     @Override
     public int run(Bootstrap bootstrap) throws Throwable {
-        JenkinsfileRunnerLauncher launcher = new JenkinsfileRunnerLauncher(bootstrap);
-
+        JenkinsLauncher launcher = createLauncherFor(bootstrap);
         return launcher.launch();
+    }
+
+    private JenkinsLauncher createLauncherFor(Bootstrap bootstrap) {
+        if(bootstrap.cliOnly) {
+            return new CLILauncher(bootstrap);
+        } else {
+            return new JenkinsfileRunnerLauncher(bootstrap);
+        }
     }
 }

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/CLILauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/CLILauncher.java
@@ -1,0 +1,70 @@
+package io.jenkins.jenkinsfile.runner;
+
+import hudson.cli.CLICommand;
+import hudson.security.ACL;
+import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Sets up a Jenkins environment that provides an interactive CLI.
+ */
+public class CLILauncher extends JenkinsLauncher {
+    public CLILauncher(Bootstrap bootstrap) {
+        super(bootstrap);
+    }
+
+    @Override
+    protected int doLaunch() throws Exception {
+        // so that the CLI has all the access to the system
+        ACL.impersonate(ACL.SYSTEM);
+        BufferedReader commandIn = new BufferedReader(new InputStreamReader(System.in));
+        String line;
+        System.out.printf("Connected to Jenkins!%nType 'help' for a list of available commands, or 'exit' to quit.%n");
+        System.out.print(" > ");
+        while ((line = commandIn.readLine()) != null) {
+            if(line.equalsIgnoreCase("exit")) {
+                break;
+            } else if(line.isEmpty()) {
+                continue;
+            }
+            tryRunCommand(line);
+            System.out.print(" > ");
+        }
+        System.out.println("bye");
+        return 0;
+    }
+
+    private void tryRunCommand(String commandLine) {
+        try {
+            String[] parts = commandLine.split(" ", 2);
+            CLICommand command = CLICommand.clone(parts[0]);
+            if(command == null) {
+                System.err.println("No such command, try 'help'.");
+                return;
+            }
+            command.main(findArgsFromLineParts(parts), Locale.getDefault(), System.in, System.out, System.err);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.err.println("An unexpected error occurred executing this command.");
+        }
+    }
+
+    private List<String> findArgsFromLineParts(String[] commandLineParts) {
+        if(commandLineParts.length > 1) {
+            return Arrays.asList(commandLineParts[1].split(" "));
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected String getThreadName() {
+        return "Jenkins CLI";
+    }
+}

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -1,0 +1,136 @@
+package io.jenkins.jenkinsfile.runner;
+
+import hudson.ClassicPluginStrategy;
+import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
+import io.jenkins.jenkinsfile.runner.util.HudsonHomeLoader;
+import jenkins.slaves.DeprecatedAgentProtocolMonitor;
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.webapp.Configuration;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebXmlConfiguration;
+
+import javax.servlet.ServletContext;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Shared behaviour for different modes of launching an embedded Jenkins in the context of jenkinsfile-runner.
+ */
+public abstract class JenkinsLauncher extends JenkinsEmbedder {
+    protected final Bootstrap bootstrap;
+    /**
+     * Keep the reference around to prevent them from getting GCed.
+     */
+    private final Set<Object> noGc = new HashSet<>();
+
+    public JenkinsLauncher(Bootstrap bootstrap) {
+        this.bootstrap = bootstrap;
+        if(bootstrap.runHome != null) {
+            if(!bootstrap.runHome.isDirectory()) {
+                throw new IllegalArgumentException("--runHome is not a directory: " + bootstrap.runHome.getAbsolutePath());
+            }
+            if(bootstrap.runHome.list().length > 0) {
+                throw new IllegalArgumentException("--runHome directory is not empty: " + bootstrap.runHome.getAbsolutePath());
+            }
+            //Override homeLoader to use existing directory instead of creating temporary one
+            this.homeLoader = new HudsonHomeLoader.UseExisting(bootstrap.runHome);
+        }
+    }
+
+    /**
+     * Sets up Jetty without any actual TCP port serving HTTP.
+     */
+    @Override
+    protected ServletContext createWebServer() throws Exception {
+        QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10);
+        server = new Server(queuedThreadPool);
+
+        WebAppContext context = new WebAppContext(bootstrap.warDir.getPath(), contextPath);
+        context.setClassLoader(getClass().getClassLoader());
+        context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
+        context.addBean(new NoListenerConfiguration(context));
+        server.setHandler(context);
+        context.getSecurityHandler().setLoginService(configureUserRealm());
+        context.setResourceBase(bootstrap.warDir.getPath());
+
+        server.start();
+
+        localPort = -1;
+
+        setPluginManager(new PluginManagerImpl(context.getServletContext(), bootstrap.pluginsDir));
+
+        return context.getServletContext();
+    }
+
+    public int launch() throws Throwable {
+        Thread currentThread = Thread.currentThread();
+        String originalThreadName = currentThread.getName();
+        currentThread.setName(getThreadName());
+        before();
+        try {
+            return doLaunch();
+        } finally {
+            after();
+            currentThread.setName(originalThreadName);
+        }
+    }
+
+    /**
+     * @return the thread name to use for executing the action
+     */
+    protected abstract String getThreadName();
+
+    /**
+     * Actually launches the Jenkins instance, without any time out or output message.
+     * @return the return code for the process
+     */
+    protected abstract int doLaunch() throws Exception;
+
+    @Override
+    public void recipe() {
+        // Not action needed so far
+    }
+
+    /**
+     * Supply a dummy {@link LoginService} that allows nobody.
+     */
+    @Override
+    protected LoginService configureUserRealm() {
+        return new HashLoginService();
+    }
+
+    @Override
+    public void before() throws Throwable {
+        setLogLevels();
+        super.before();
+    }
+
+    /**
+     * We don't want to clutter console with log messages, so kill of any unimportant ones.
+     */
+    private void setLogLevels() {
+        Logger.getLogger("").setLevel(Level.WARNING);
+        // Prevent warnings for plugins with old plugin POM (JENKINS-54425)
+        Logger.getLogger(ClassicPluginStrategy.class.getName()).setLevel(Level.SEVERE);
+        Logger l = Logger.getLogger(DeprecatedAgentProtocolMonitor.class.getName());
+        l.setLevel(Level.OFF);
+        noGc.add(l);    // the configuration will be lost if Logger gets GCed.
+    }
+
+    /**
+     * Skips the clean up.
+     *
+     * This was initially motivated by SLF4J leaving gnarly messages.
+     * The whole JVM is going to die anyway, so we don't really care about cleaning up anything nicely.
+     */
+    @Override
+    public void after() throws Exception {
+        jenkins = null;
+        super.after();
+    }
+}

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerLauncher.java
@@ -1,116 +1,22 @@
 package io.jenkins.jenkinsfile.runner;
 
-import hudson.ClassicPluginStrategy;
 import hudson.security.ACL;
 import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
 import io.jenkins.jenkinsfile.runner.bootstrap.ClassLoaderBuilder;
-import io.jenkins.jenkinsfile.runner.util.HudsonHomeLoader;
-import jenkins.slaves.DeprecatedAgentProtocolMonitor;
-import org.eclipse.jetty.security.HashLoginService;
-import org.eclipse.jetty.security.LoginService;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.eclipse.jetty.webapp.Configuration;
-import org.eclipse.jetty.webapp.WebAppContext;
-import org.eclipse.jetty.webapp.WebXmlConfiguration;
 
-import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Set up of Jenkins environment for executing a single Jenkinsfile.
  *
  * @author Kohsuke Kawaguchi
  */
-public class JenkinsfileRunnerLauncher extends JenkinsEmbedder {
+public class JenkinsfileRunnerLauncher extends JenkinsLauncher {
     private static final String RUNNER_CLASS_NAME = "io.jenkins.jenkinsfile.runner.Runner";
-    private final Bootstrap bootstrap;
-    /**
-     * Keep the reference around to prevent them from getting GCed.
-     */
-    private final Set<Object> noGc = new HashSet<>();
 
     public JenkinsfileRunnerLauncher(Bootstrap bootstrap) {
-        this.bootstrap = bootstrap;
-        if(bootstrap.runHome != null) {
-            if(!bootstrap.runHome.isDirectory()) throw new IllegalArgumentException("--runHome is not a directory: " + bootstrap.runHome.getAbsolutePath());
-            if(bootstrap.runHome.list().length > 0) throw new IllegalArgumentException("--runHome directory is not empty: " + bootstrap.runHome.getAbsolutePath());
-            //Override homeLoader to use existing directory instead of creating temporary one
-            this.homeLoader = new HudsonHomeLoader.UseExisting(bootstrap.runHome);
-        }
-    }
-
-    /**
-     * Sets up Jetty without any actual TCP port serving HTTP.
-     */
-    @Override
-    protected ServletContext createWebServer() throws Exception {
-        QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10);
-        server = new Server(queuedThreadPool);
-
-        WebAppContext context = new WebAppContext(bootstrap.warDir.getPath(), contextPath);
-        context.setClassLoader(getClass().getClassLoader());
-        context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
-        context.addBean(new NoListenerConfiguration(context));
-        server.setHandler(context);
-        context.getSecurityHandler().setLoginService(configureUserRealm());
-        context.setResourceBase(bootstrap.warDir.getPath());
-
-        server.start();
-
-        localPort = -1;
-
-        setPluginManager(new PluginManagerImpl(context.getServletContext(), bootstrap.pluginsDir));
-
-        return context.getServletContext();
-    }
-
-    @Override
-    public void recipe() throws Exception {
-        // Not action needed so far
-    }
-
-    /**
-     * Supply a dummy {@link LoginService} that allows nobody.
-     */
-    @Override
-    protected LoginService configureUserRealm() {
-        return new HashLoginService();
-    }
-
-    @Override
-    public void before() throws Throwable {
-        setLogLevels();
-        super.before();
-    }
-
-    /**
-     * We don't want to clutter console with log messages, so kill of any unimportant ones.
-     */
-    private void setLogLevels() {
-        Logger.getLogger("").setLevel(Level.WARNING);
-        // Prevent warnings for plugins with old plugin POM (JENKINS-54425)
-        Logger.getLogger(ClassicPluginStrategy.class.getName()).setLevel(Level.SEVERE);
-        Logger l = Logger.getLogger(DeprecatedAgentProtocolMonitor.class.getName());
-        l.setLevel(Level.OFF);
-        noGc.add(l);    // the configuration will be lost if Logger gets GCed.
-    }
-
-    /**
-     * Skips the clean up.
-     *
-     * This was initially motivated by SLF4J leaving gnarly messages.
-     * The whole JVM is going to die anyway, so we don't really care about cleaning up anything nicely.
-     */
-    @Override
-    public void after() throws Exception {
-        jenkins = null;
-        super.after();
+        super(bootstrap);
     }
 
     //TODO: add support of timeout
@@ -118,23 +24,12 @@ public class JenkinsfileRunnerLauncher extends JenkinsEmbedder {
      * Launch the Jenkins instance
      * No time out and no output message
      */
-    public int launch() throws Throwable {
-        int returnCode = -1;
-        Thread t = Thread.currentThread();
-        String currentThreadName = t.getName();
-        t.setName("Executing "+ env.displayName());
-        before();
-        try {
-            // so that test code has all the access to the system
-            ACL.impersonate(ACL.SYSTEM);
-            Class<?> c = bootstrap.hasClass(RUNNER_CLASS_NAME)? Class.forName(RUNNER_CLASS_NAME) : getRunnerClassFromJar();
-            returnCode = (int)c.getMethod("run", Bootstrap.class).invoke(c.newInstance(), bootstrap);
-        } finally {
-            after();
-            t.setName(currentThreadName);
-        }
-
-        return returnCode;
+    @Override
+    protected int doLaunch() throws Exception {
+        // so that test code has all the access to the system
+        ACL.impersonate(ACL.SYSTEM);
+        Class<?> c = bootstrap.hasClass(RUNNER_CLASS_NAME)? Class.forName(RUNNER_CLASS_NAME) : getRunnerClassFromJar();
+        return (int)c.getMethod("run", Bootstrap.class).invoke(c.newInstance(), bootstrap);
     }
 
     private Class<?> getRunnerClassFromJar() throws IOException, ClassNotFoundException {
@@ -143,5 +38,10 @@ public class JenkinsfileRunnerLauncher extends JenkinsEmbedder {
                 .make();
 
         return cl.loadClass(RUNNER_CLASS_NAME);
+    }
+
+    @Override
+    protected String getThreadName() {
+        return "Executing " + env.displayName();
     }
 }


### PR DESCRIPTION
# Ellipsis
As suggested by https://github.com/jenkinsci/jenkinsfile-runner/issues/178, this PR adds a way to access the Jenkins CLI from `jenkinsfile-runner`.

# Technical Overview
To support the new mode of execution, a new `JenkinsLauncher` superclass has been extracted from the existing `JenkinsfileRunnerLauncher`, to abstract Jenkins setup capabilities. A new subclass `CliLauncher` has been added that provides a loop forwarding commands via `CliCommand.clone()`. `App` now has a switch on the new `Bootstrap.cliOnly` flag, and decides which implementation to use.

This flag can be set via `--cli` or `-c`, and additionally via a `FORCE_JENKINS_CLI` environment variable. The latter is mainly intended for use with Docker (otherwise we'd need a custom entrypoint script or a separate `Dockerfile` just for CLI).

# Usage
````bash
$ docker run --rm -it -e FORCE_JENKINS_CLI=true jenkinsfile-runner:dev
Connected to Jenkins!
Type 'help' for a list of available commands, or 'exit' to quit.
 > show-plugins
No such command, try 'help'.
 > list-plugins
ace-editor                         JavaScript GUI Lib: ACE Editor bundle plugin                     1.1
...
workflow-multibranch               Pipeline: Multibranch                                            2.21
 > who-am-i
Authenticated as: anonymous
Authorities:
  anonymous
 > bye
$ app/target/appassembler/bin/jenkinsfile-runner -w /tmp/jenkins -p /tmp/jhome/plugins --cli
...
````

I hope this is somewhat similar to what was meant with "new engine" in #178.

Fixes #178