### PR TITLE
Add ParameterDefinitions to WorkflowJob

### DIFF
--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -5,6 +5,9 @@ import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Failure;
 import hudson.model.ParametersAction;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.model.queue.QueueTaskFuture;
 import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
@@ -45,6 +48,11 @@ public class Runner {
         WorkflowJob w = j.createProject(WorkflowJob.class, bootstrap.jobName);
         w.updateNextBuildNumber(bootstrap.buildNumber);
         w.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.PERFORMANCE_OPTIMIZED));
+        List<ParameterDefinition> parameterDefinitions = new ArrayList<>(); 
+        for (String parameterName : bootstrap.workflowParameters.keySet()) {
+          parameterDefinitions.add(new StringParameterDefinition(parameterName,""));
+        }
+        w.addProperty(new ParametersDefinitionProperty(parameterDefinitions));
         w.setDefinition(new CpsScmFlowDefinition(
                 new FileSystemSCM(bootstrap.jenkinsfile.getParent()), bootstrap.jenkinsfile.getName()));
 


### PR DESCRIPTION
Create clean parameter definitions in the workflow job to avoid the need to set following JAVA_OPTS:
```
-e "JAVA_OPTS=-Dhudson.model.ParametersAction.keepUndefinedParameters=true"
```
Example:
Pipeline
```
node {
        stage('Build') {
               echo "FOO: '"+params.FOO+"'"
               echo "BAR: '"+params.BAR+"'"
               echo "BAZ: '"+params.BAZ+"'"
            }
    }
```
Parameters
```
 -a FOO= -a BAR="" -a BAZ="xzy"
```
Output of the pipeline
```
[Pipeline] echo
FOO: ''
[Pipeline] echo
BAR: ''
[Pipeline] echo
BAZ: 'xzy'

```
