### PR TITLE
Add a `--keep-undefined-parameters` option so that users can pass parameters without declaring them in job properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The executable of Jenkinsfile Runner allows its invocation with these cli option
                                Requires Jenkins 2.119 or above
  -a (--arg)                  : Parameters to be passed to workflow job. Use
                                multiple -a switches for multiple params
+ -u (--keep-undefined-parameters) : Keep undefined parameters if set, defaults
+                                    to false.
  -f (--file) FILE            : Path to Jenkinsfile (or directory containing a
                                Jenkinsfile) to run, default to ./Jenkinsfile.
  -ns (--no-sandbox)          : Disable workflow job execution within sandbox

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -103,6 +103,10 @@ public class Bootstrap {
     @Option(name = "-h", aliases = { "--help"}, usage = "Prints help information.", help = true, forbids = { "-v", "-w", "-p", "-f", "--runWorkspace" })
     public boolean help;
 
+    @Option(name = "-u", aliases = { "--keep-undefined-parameters"}, usage = "Keep undefined parameters if set")
+    public boolean keepUndefinedParameters = false;
+
+
     public static void main(String[] args) throws Throwable {
         // break for attaching profiler
         if (Boolean.getBoolean("start.pause")) {
@@ -198,6 +202,10 @@ public class Bootstrap {
         }
 
         if (this.jobName.isEmpty()) this.jobName = DEFAULT_JOBNAME;
+
+        if (this.keepUndefinedParameters) {
+          System.setProperty("hudson.model.ParametersAction.keepUndefinedParameters", "true");
+        }
     }
 
     private String getVersion() throws IOException {


### PR DESCRIPTION
Replace #209