### PR TITLE
Docker bootstrap script

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -59,7 +59,11 @@ Optionally, if you need special Jenkins configuration, you can mount JCasC YAML 
 for available options and the [JCasC demo](demo/casc/README.md) for an example.
 
 To get an interactive Jenkins CLI shell in the container, pass
-`-i -e FORCE_JENKINS_CLI=true` to `docker run` as extra parameters.
+`-i` to `docker run` and append `cli` after the image name like this:
+
+```bash
+docker run -i --rm jenkinsfile-runner:my-production-jenkins cli
+```
 
 ## Debug
 In case you want to debug Jenkinsfile Runner, you need to use the "Vanilla" Docker image built following the steps mentioned in the section above.

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,22 +2,25 @@
 # To avoid downloading everything from the internet and using developer's cache
 
 FROM openjdk:8-jdk
-ENV JENKINS_UC https://updates.jenkins.io
-ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
+
+ARG JENKINS_REF=/usr/share/jenkins/ref
+ARG JENKINS_HOME=/app/jenkins
+
+ENV JENKINS_REF ${JENKINS_REF}
+ENV JENKINS_HOME ${JENKINS_HOME}
+
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc
-RUN echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml
+RUN mkdir -p /app ${JENKINS_REF}/plugins ${JENKINS_REF}/casc
 
 COPY app/target/appassembler /app
 COPY vanilla-package/target/war/jenkins.war /usr/share/jenkins/jenkins.war
-RUN unzip /usr/share/jenkins/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
-COPY vanilla-package/target/plugins /usr/share/jenkins/ref/plugins
+RUN unzip /usr/share/jenkins/jenkins.war -d ${JENKINS_HOME} && \
+  rm -rf ${JENKINS_HOME}/scripts ${JENKINS_HOME}/jsbundles ${JENKINS_HOME}/css ${JENKINS_HOME}/images ${JENKINS_HOME}/help ${JENKINS_HOME}/WEB-INF/detached-plugins ${JENKINS_HOME}/winstone.jar ${JENKINS_HOME}/WEB-INF/jenkins-cli.jar ${JENKINS_HOME}/WEB-INF/lib/jna-4.5.2.jar
+COPY vanilla-package/target/plugins ${JENKINS_REF}/plugins
 COPY jenkinsfile-runner-launcher /app/bin
 
-VOLUME /usr/share/jenkins/ref/casc
+VOLUME ${JENKINS_REF}/casc
 
-ENTRYPOINT ["/app/bin/jenkinsfile-runner-launcher", \
-            "-w", "/app/jenkins",\
-            "-p", "/usr/share/jenkins/ref/plugins",\
-            "-f", "/workspace"]
+ENTRYPOINT ["/app/bin/jenkinsfile-runner-launcher"]
+
+CMD ["run"]

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -143,10 +143,6 @@ public class Bootstrap {
             System.exit(0);
         }
 
-        if (System.getenv("FORCE_JENKINS_CLI") != null) {
-            this.cliOnly = true;
-        }
-
         if (this.version != null && !isVersionSupported()) {
             System.err.printf("Jenkins version [%s] not suported by this jenkinsfile-runner version (requires %s). \n",
                     this.version,

--- a/jenkinsfile-runner-launcher
+++ b/jenkinsfile-runner-launcher
@@ -1,7 +1,54 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-if [ -n "$DEBUG" ] ; then
-  export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 $JAVA_OPTS"
+if [[ -z "${JENKINS_HOME}" ]] || [[ -z "${JENKINS_REF}" ]]; then
+  echo "$0: Environment variables JENKINS_HOME and JENKINS_REF need to be set!" >&2
+  exit 1
+elif [[ ! -d "${JENKINS_HOME}" ]]; then
+  echo "$0: JENKINS_HOME at ${JENKINS_HOME} does not exist." >&2
+  exit 1
+elif [[ ! -d "${JENKINS_REF}" ]]; then
+  echo "$0: JENKINS_REF at ${JENKINS_REF} does not exist." >&2
+  exit 1
 fi
 
-. /app/bin/jenkinsfile-runner
+export JENKINS_WORKSPACE="${JENKINS_WORKSPACE:-/workspace}"
+export JENKINS_BUILD_DIR="${JENKINS_BUILD_DIR:-/build}"
+export CASC_JENKINS_CONFIG="${CASC_JENKINS_CONFIG:-${JENKINS_REF}/casc}"
+export JENKINS_PLUGIN_DIR="${JENKINS_PLUGIN_DIR:-${JENKINS_REF}/plugins}"
+
+export JENKINS_UC="${JENKINS_UC:-https://updates.jenkins.io}"
+
+LAUNCHER_PARAMS=("-w" "${JENKINS_HOME}" "-p" "${JENKINS_REF}/plugins")
+
+if [[ -n "${DEBUG}" ]]; then
+  export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 ${JAVA_OPTS:-}"
+  echo "Make sure to expose the debug port by providing -p 5005:5005 to docker run"
+fi
+
+if [[ "$#" -gt 0 ]]; then
+  case "$1" in
+    run)
+      LAUNCHER_PARAMS+=("-f" "${JENKINS_WORKSPACE}" "--runWorkspace" "${JENKINS_BUILD_DIR}")
+      ;;
+    cli)
+      LAUNCHER_PARAMS+=("--cli")
+      ;;
+    *)
+      echo "$0: Unknown action $1. Try $0 [run|cli]"
+      echo "    run: Launch a Jenkinsfile build."
+      echo "    cli: Attach an interactive Jenkins shell."
+      exit 1
+      ;;
+  esac
+
+  if [[ "$#" -gt 1 ]]; then
+    LAUNCHER_PARAMS+=("${@:1}")
+  fi
+fi
+
+if [[ -x "/app/bin/jenkinsfile-runner" ]]; then
+  /app/bin/jenkinsfile-runner "${LAUNCHER_PARAMS[@]}"
+else
+  echo "$0: /app/bin/jenkinsfile-runner needs to be an executable file." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Ellipsis
This MR adds a bootstrap script for Docker, which allows us to switch between Jenkinsfile and CLI mode seamlessly without having to mess with environment variables. It also streamlines a few operations in the Dockerfiles to use environment variables.

This is as suggested by @oleg-nenashev in https://github.com/jenkinsci/jenkinsfile-runner/pull/207#issuecomment-544489650, and inherently requires that #207 (CLI mode) be merged first.

Clean diff without the #207 changes here: https://github.com/xxyy/jenkinsfile-runner/compare/178/cli-mode...xxyy:docker-bootstrap-script?expand=1