### PR TITLE
Add javax.annotation as a dependency

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -23,5 +23,10 @@
       <artifactId>version-number</artifactId>
       <version>1.6</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Could not compile project without it locally (osx, oracle-jdk from homebrew)