### PR TITLE
Document how to run the JCasC demo locally with Vanilla packages

### DIFF
--- a/demo/casc/README.md
+++ b/demo/casc/README.md
@@ -10,26 +10,36 @@ Docker image to `/usr/share/jenkins/ref/casc`, where it is recognized by
 Jenkins. Note that this does not need to be a single file, but can be
 split up into multiple YAMLs.
 
-Running the demo
-----------------
-The following commands need to be run in the directory containing this file.
+When launched, the Pipeline will print the variable that was set via JCasC.
+Execution log output:
 
-If you have not built the Docker image yet:
-(Refer to the [Packaging to Docker image](../../DOCKER.md) page for details on the
-Docker packaging process)
-````bash
-docker build -t jenkinsfile-runner:my-production-jenkins ../..
-````
-
-Now that the image is built, run it, mounting the `config` directory:
-````bash
-docker run --rm -v $PWD:/workspace -v $PWD/config:/usr/share/jenkins/ref/casc jenkinsfile-runner:my-production-jenkins
-````
-
-This will print the variable that was set via JCasC.
-````
+```
 ...
 [Pipeline] echo
 An environment variable configured via JCasC: a value configured via JCasC
 ...
-````
+```
+
+## Running the demo locally
+
+Once you build the repository, launch the following command:
+
+```bash
+CASC_JENKINS_CONFIG=config/jenkins.yaml java -jar ../../app/target/jenkinsfile-runner-standalone.jar \
+  -w ../../vanilla-package/target/war -p ../../vanilla-package/target/plugins/ -f .
+```
+
+## Running the demo in Docker
+
+If you have not built the Docker image yet:
+(Refer to the [Packaging to Docker image](../../DOCKER.md) page for details on the
+Docker packaging process)
+
+```bash
+docker build -t jenkinsfile-runner:my-production-jenkins ../..
+```
+
+Now that the image is built, run it, mounting the `config` directory:
+```bash
+docker run --rm -v $PWD:/workspace -v $PWD/config:/usr/share/jenkins/ref/casc jenkinsfile-runner:my-production-jenkins
+```


### PR DESCRIPTION
Follow-up to #260 by @chhex . The demo now can run with the Vanilla packaging in this repository, so it makes sense to document the scenario