### PR TITLE
Speedup vanilla package testing: .dockerignore and a development mode flag in tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,18 @@
 Dockerfile*
+
+# App and intermediate build dirs
+app/target/jenkinsfile-runner*
+app/target/classes
+app/target/maven-archiver
+app/archive-tmp
+bootstrap/target
+payload/target
+payload-dependencies/target
+setup/target
+
+# Tests
+tests
+
+# Documentation
+demo
+docs

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,3 +17,4 @@ test:
 	./tests-cwp-jdk11.sh
 	./tests-vanilla.sh
 	./tests-negative-scenarios.sh
+	./tests-vanilla-negative-scenarios.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,5 +9,13 @@ The version of shUnit2 we are using does not work with the default bash shell on
 
 More information on updating your bash shell can be found here [Upgrading bash on macOs](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)
 
+## Developer mode
 
+Building of production Docker packages may take a while.
+For vanilla package tests is possible to use a developer mode to speedup local testing.
+Example:
 
+```bash
+make clean prepare
+JFR_DEVEL=true bash ./tests-vanilla.sh
+```

--- a/tests/tests-vanilla.sh
+++ b/tests/tests-vanilla.sh
@@ -16,7 +16,12 @@ oneTimeSetUp() {
   mkdir -p "$working_directory"
 
   cd "$src_directory"
-  result=$(docker build -t "$jenkinsfile_runner_tag" --no-cache . | grep 'Successfully tagged')
+  docker_build_options="--no-cache"
+  if [ -n "$JFR_DEVEL" ] ; then
+    echo "Running tests against the development image"
+    docker_build_options="-f Dockerfile-dev"
+  fi
+  result=$(docker build -t "$jenkinsfile_runner_tag" $docker_build_options . | grep 'Successfully tagged')
   execution_should_success "$?" "$jenkinsfile_runner_tag" "$result"
 
   cd "$current_directory"


### PR DESCRIPTION
FYI @varyvol @fcojfernandez 
