### PR TITLE
Fix demos in the CI Pipeline

### DIFF
--- a/demo/cwp-jdk11/Makefile
+++ b/demo/cwp-jdk11/Makefile
@@ -16,7 +16,7 @@ clean:
 
 
 .copySource:
-	rsync -av --exclude='demo' $(shell pwd)/../../ $(shell pwd)/source
+	rsync -av --exclude='.git' --exclude='demo' --exclude='tests' --exclude='*/target/*' $(shell pwd)/../../ $(shell pwd)/source
 
 .build/cwp-cli-${CWP_VERSION}.jar:
 	rm -rf .build

--- a/demo/cwp/Makefile
+++ b/demo/cwp/Makefile
@@ -15,7 +15,7 @@ clean:
 	rm -rf out
 
 .copySource:
-	rsync -av --exclude='demo' $(shell pwd)/../../ $(shell pwd)/source
+	rsync -av --exclude='.git' --exclude='demo' --exclude='tests' --exclude='*/target/*' $(shell pwd)/../../ $(shell pwd)/source
 
 .build/cwp-cli-${CWP_VERSION}.jar:
 	rm -rf .build

--- a/demo/databound/Makefile
+++ b/demo/databound/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -rf source
 
 .copySource:
-	rsync -av --exclude='demo' $(shell pwd)/../../ $(shell pwd)/source
+	rsync -av --exclude='.git' --exclude='demo' --exclude='tests' --exclude='*/target/*' $(shell pwd)/../../ $(shell pwd)/source
 
 .build/cwp-cli-${CWP_VERSION}.jar:
 	rm -rf .build

--- a/demo/databound/packager-config.yml
+++ b/demo/databound/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.150.2"
+      base: "jenkins/jenkins:2.204.1"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.150.2"
+    version: "2.204.1"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"


### PR DESCRIPTION
I am not sure whether `databound` is needed anymore, AFAICT it is superseded by a simple unit test for the Vanilla image in #285 . CC @varyvol 