### PR TITLE
Vanilla tests: Increase timeout to two minutes

### DIFF
--- a/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/ParametersTest.java
+++ b/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/ParametersTest.java
@@ -27,7 +27,7 @@ public class ParametersTest {
     public final SystemOutRule systemOut = new SystemOutRule().enableLog();
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(30);
+    public Timeout globalTimeout = Timeout.seconds(120);
 
     @Test
     public void scriptedPipeline() throws Throwable {

--- a/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/SmokeTest.java
+++ b/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/SmokeTest.java
@@ -27,7 +27,7 @@ public class SmokeTest {
     public final SystemErrRule systemErr = new SystemErrRule().enableLog();
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(30);
+    public Timeout globalTimeout = Timeout.seconds(120);
 
     @Test
     public void helloWorld() throws Throwable {


### PR DESCRIPTION
Otherwise tests fail on DockerHub, likely the builder is very slow there