### PR TITLE
Replace jsr-305 annotations with SpotBugs ones

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -6,7 +6,7 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/FileSystemSCM.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/FileSystemSCM.java
@@ -16,9 +16,9 @@ import hudson.util.DirScanner;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 
@@ -43,7 +43,7 @@ public class FileSystemSCM extends SCM {
     }
 
     @Override
-    public void checkout(@Nonnull Run<?, ?> build, @Nonnull Launcher launcher, @Nonnull FilePath workspace, @Nonnull TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
+    public void checkout(@NonNull Run<?, ?> build, @NonNull Launcher launcher, @NonNull FilePath workspace, @NonNull TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
         new FilePath(new File(dir)).copyRecursiveTo(new DirScanner.Glob("**/*", null, false), workspace, "**/*");
     }
 
@@ -53,7 +53,7 @@ public class FileSystemSCM extends SCM {
      * Jenkinsfile Runner doesn't need to do polling, so this method is not needed.
      */
     @Override
-    public SCMRevisionState calcRevisionsFromBuild(@Nonnull Run<?, ?> build, @Nullable FilePath workspace, @Nullable Launcher launcher, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+    public SCMRevisionState calcRevisionsFromBuild(@NonNull Run<?, ?> build, @Nullable FilePath workspace, @Nullable Launcher launcher, @NonNull TaskListener listener) throws IOException, InterruptedException {
         return SCMRevisionState.NONE;
     }
 
@@ -63,7 +63,7 @@ public class FileSystemSCM extends SCM {
      * Jenkinsfile Runner doesn't need to do polling, so this method is not needed.
      */
     @Override
-    public PollingResult compareRemoteRevisionWith(@Nonnull Job<?, ?> project, @Nullable Launcher launcher, @Nullable FilePath workspace, @Nonnull TaskListener listener, @Nonnull SCMRevisionState baseline) throws IOException, InterruptedException {
+    public PollingResult compareRemoteRevisionWith(@NonNull Job<?, ?> project, @Nullable Launcher launcher, @Nullable FilePath workspace, @NonNull TaskListener listener, @NonNull SCMRevisionState baseline) throws IOException, InterruptedException {
         return PollingResult.NO_CHANGES;
     }
 

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
@@ -72,7 +72,7 @@ import java.util.Locale;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/WarExploder.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/WarExploder.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * WAR Exploder Implementation for Jenkinsfile Runner.

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/util/HudsonHomeLoader.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/util/HudsonHomeLoader.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * Controls how <tt>JENKINS_HOME</tt> is initialized.

--- a/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/JFRTestUtil.java
+++ b/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/JFRTestUtil.java
@@ -4,8 +4,8 @@ import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
Fixes #296 

Similarly to jenkinsci/jenkins#4604 , we should remove JSR annotations and use ones supplied by SpotBugs.

It should also help towards building JFR with JDK 11.

This change as it stands introduces several "deprecated usage" compile warnings because of the bom enforced version of `org.jenkins-ci:version-number` library. Once the bom is updated and the library version is changed from `1.6` to at least `1.7`, the warnings will disappear.