### PR TITLE
Replace custom Plugin management code by Plugin Installation Manager

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -22,5 +22,9 @@
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugin-management</groupId>
+      <artifactId>plugin-management-library</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Util.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Util.java
@@ -11,6 +11,10 @@ import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jenkins.tools.pluginmanager.config.Config;
+import io.jenkins.tools.pluginmanager.impl.PluginManager;
+
 
 public class Util {
 
@@ -45,5 +49,29 @@ public class Util {
             }
         }
         return destDir;
+    }
+
+    public interface PluginManagerConfigurator {
+        void configure(Config.Builder configBuilder);
+    }
+
+    @NonNull
+    public static PluginManager initPluginManager(File pluginsDir, PluginManagerConfigurator configurator) {
+        Config.Builder configBuilder = Config.builder()
+                //.withJenkinsWar(jenkinsWar.getAbsolutePath())
+                .withPluginDir(pluginsDir)
+                .withShowAvailableUpdates(true)
+                .withIsVerbose(true)
+                .withDoDownload(false);
+        configurator.configure(configBuilder);
+        Config config = configBuilder.build();
+
+        PluginManager pluginManager = new PluginManager(config);
+        //pluginManager.setCm(new CacheManager(cacheDir.toPath(), true));
+        //pluginManager.setJenkinsVersion(new VersionNumber("2.222.1"));
+        //pluginManager.setLatestUcJson(latestUcJson);
+        //pluginManager.setLatestUcPlugins(latestUcJson.getJSONObject("plugins"));
+        //pluginManager.setPluginInfoJson(pluginManager.getJson(pluginVersionsFile.toURI().toURL(), "plugin-versions"));
+        return pluginManager;
     }
 }

--- a/packaging/docker/unix/debian-jdk8/Dockerfile
+++ b/packaging/docker/unix/debian-jdk8/Dockerfile
@@ -11,8 +11,8 @@ RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.w
 FROM openjdk:8-jdk
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 0.1-alpha-10
-ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/plugin-management-parent-pom-$JENKINS_PM_VERSION/jenkins-plugin-manager-$JENKINS_PM_VERSION.jar
+ENV JENKINS_PM_VERSION 1.1.2
+ENV JENKINS_PM_URL https://repo.jenkins-ci.org/releases/io/jenkins/plugin-management/plugin-management-cli/${PLUGIN_MANAGER_TOOL_VERSION}/plugin-management-cli-${JENKINS_PM_VERSION}.jar -O tmp/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
 USER root
 RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
     && echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml \

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@ THE SOFTWARE.
     <jetty.version>9.4.30.v20200611</jetty.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <findbugs.failOnError>false</findbugs.failOnError>
+    <!-- https://github.com/jenkinsci/plugin-installation-manager-tool -->
+    <plugin.installation.manager.version>1.1.2</plugin.installation.manager.version>
   </properties>
 
   <dependencyManagement>
@@ -89,6 +91,12 @@ THE SOFTWARE.
         <artifactId>support-log-formatter</artifactId>
         <version>1.0</version>
       </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugin-management</groupId>
+        <artifactId>plugin-management-library</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+
       <!-- TODO(oleg-nenashev): Remove after 2.238: https://github.com/jenkinsci/jenkins/pull/4702 -->
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
* [x] Replace base logic
* [ ] Looks like it is not going to work too well without exposing plugin cache directory and similar options so that we do not have  to download update center data every time.
* [ ] We need to handle Jenkins WAR stuff. It is not trivial, because Jenkinsfile Runner expects the exploded WAR, and the Plugin Installation Manager does not support it at the moment
* [ ] Include demo
* [ ] Add tests

Closes #248 