### PR TITLE
Properly export the minimum supported Jenkins version

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -46,6 +46,7 @@
           <archive>
             <manifest>
               <mainClass>io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap</mainClass>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
           </archive>
         </configuration>
@@ -62,6 +63,19 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <resources>
+            <resource>
+              <directory>src/main/resources-filtered</directory>
+              <filtering>true</filtering>
+            </resource>
+          </resources>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/app/src/main/resources-filtered/jenkins.properties
+++ b/app/src/main/resources-filtered/jenkins.properties
@@ -1,0 +1,1 @@
+jenkins.version=${jenkins.version}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -233,20 +233,19 @@ public class Bootstrap {
     }
 
     private String getVersion() throws IOException {
-       return readPropertyFromPom("version");
+       return getClass().getPackage().getImplementationVersion();
     }
 
     private String getMininumJenkinsVersion() throws IOException {
-        return readPropertyFromPom("jenkins.version");
+        return readJenkinsPomProperty("jenkins.version");
     }
 
     private boolean isVersionSupported() throws IOException {
         return new VersionNumber(this.version).isNewerThanOrEqualTo(new VersionNumber(this.getMininumJenkinsVersion()));
     }
 
-    private String readPropertyFromPom(String key) throws IOException {
-        String propertiesPath = "/META-INF/maven/io.jenkins.jenkinsfile-runner/jenkinsfile-runner/pom.properties";
-        try (InputStream pomProperties = this.getClass().getResourceAsStream(propertiesPath)) {
+    private String readJenkinsPomProperty(String key) throws IOException {
+        try (InputStream pomProperties = this.getClass().getResourceAsStream("/jenkins.properties")) {
             Properties props = new Properties();
             props.load(pomProperties);
             return props.getProperty(key);


### PR DESCRIPTION
Fixes #257 .

What happened is that when generating the pom.properties, the Maven Archiver plugin is not exactly working as one might expect ([see sources](https://github.com/apache/maven-archiver/blob/eb6001d42ef5e5a1f9d5069ab252862e59e83a74/src/main/java/org/apache/maven/archiver/PomPropertiesUtil.java#L158-L162)).
So we cannot really rely on the pom.properties, IMHO we don't need to export the whole properties of the pom, so simply using the resource plugin filtering a new property file should answer the need.

After the fix:

```
$ java -jar app/target/jenkinsfile-runner-standalone.jar -jv 2.204.5
Jenkins version [2.204.5] not suported by this jenkinsfile-runner version (requires 2.235.2).
```

```
java -jar app/target/jenkinsfile-runner-standalone.jar --version
1.0-beta-15-SNAPSHOT
```