### PR TITLE
Exclude jenkins.war and executable-war.jar from Jenkinsfile Runner bundles

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -97,10 +97,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
     </dependency>

--- a/demo/cwp/packager-config.yml
+++ b/demo/cwp/packager-config.yml
@@ -14,14 +14,14 @@ buildSettings:
       source:
         dir: ./source
     docker:
-      base: "jenkins/jenkins:2.164.2"
+      base: "jenkins/jenkins:2.246"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.164.2"
+    version: "2.246"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/demo/databound/packager-config.yml
+++ b/demo/databound/packager-config.yml
@@ -21,7 +21,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.235.2"
+    version: "2.246"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
-    <jenkins.version>2.235.2</jenkins.version>
+    <jenkins.version>2.246</jenkins.version> <!-- Required for module versions in BOM: https://github.com/jenkinsci/jenkins/pull/4854 -->
     <jetty.version>9.4.30.v20200611</jetty.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <findbugs.failOnError>false</findbugs.failOnError>

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -27,16 +27,56 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!--
-      These are for compilation only, and at runtime the user specified jenkins.war
-      and its content will be used.
-    -->
+    <!-- TODO(oleg-nenashev): Support excluding the Jenkins core components from the setup bundle.
+         It was supposed to work like that according to documentation by Kohsuke,
+         but it was not a case due to the jenkins-war dependency which was pulling the WAR file, Core and modules into the bundle.
+
+         Ideally the scope should be changed to provided so that the components are not included into the lightweight Jenkinsfile Runner app package.
+      -->
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
       <version>${jenkins.version}</version>
-      <optional>true</optional>
     </dependency>
+
+    <!-- Jenkins Modules -->
+    <!-- NOTE(oleg_nenashev): Not all modules are actually needed, e.g. Agent Installer modules unlikely have any use-case in JFR.
+         At the same time, there are plugins which **may** depend on them.
+         Total size of modules is less than 400KB, so optimization is not required here for now.
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>instance-identity</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>ssh-cli-auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>slave-installer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>windows-slave-installer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>launchd-slave-installer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>upstart-slave-installer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>systemd-slave-installer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>sshd</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
@@ -59,12 +99,9 @@
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
-      <version>${jenkins.version}</version>
-      <type>executable-war</type>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This change removes the `jenkins.war` and `executable-war.jar` resources which were present in the APP packages. It has a massive impact on the bundle size while not having any impact on behavior of Jenkinsfile Runner in all configurations.

* `jenkinsfile-runner-standalone.jar` size was reduced  from 146.5 MB to 82 MB
* `jenkinsfile-runner-standalone.zip` size was reduced from 140 MB  to 75.5 MB
* Vanilla Docker image sizes are reduced by ~70Mb. It is approximately a 20% size reduction for the smallest image.

Contributes to #226 . It worth mentioning that the jenkins-core.jar and plugin JARs remain present in the bundles produced by the `app` module, so there is still some overhead and classloading conflict risks. I plan to submit a separate pull request for it so that these components stop including JARs at all (and maybe adding a separate package for that so that we do not have to pass `--war` and `--plugins` when classpath is ready... at all

