### PR TITLE
Reduce Vanilla Docker image sizes by not bundling plugin HPI files

### DIFF
--- a/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
@@ -11,8 +11,14 @@ ADD setup /jenkinsfile-runner/setup
 ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD pom.xml /jenkinsfile-runner/pom.xml
 RUN cd /jenkinsfile-runner && mvn clean package
+# Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \
+# Delete HPI files and use the archive directories instead
+RUN echo "Optimizing plugins..." && \
+  cd /jenkinsfile-runner/vanilla-package/target/plugins && \
+  rm -rf *.hpi && \
+  for f in * ; do echo "Exploding $f..." && mv "$f" "$f.hpi" ; done;
 
 FROM adoptopenjdk:11.0.8_10-jdk-hotspot
 RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*

--- a/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
@@ -11,9 +11,15 @@ ADD setup /jenkinsfile-runner/setup
 ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD pom.xml /jenkinsfile-runner/pom.xml
 RUN cd /jenkinsfile-runner && mvn clean package
+# Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
-
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \
+# Delete HPI files and use the archive directories instead
+RUN echo "Optimizing plugins..." && \
+  cd /jenkinsfile-runner/vanilla-package/target/plugins && \
+  rm -rf *.hpi && \
+  for f in * ; do echo "Exploding $f..." && mv "$f" "$f.hpi" ; done;
+  
 # Unofficial experimental image, AdoptOpenJDK does not offer official Alpine for JDK8
 FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
 ENV JENKINS_UC https://updates.jenkins.io

--- a/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
@@ -11,8 +11,14 @@ ADD setup /jenkinsfile-runner/setup
 ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD pom.xml /jenkinsfile-runner/pom.xml
 RUN cd /jenkinsfile-runner && mvn clean package
+# Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \
+# Delete HPI files and use the archive directories instead
+RUN echo "Optimizing plugins..." && \
+  cd /jenkinsfile-runner/vanilla-package/target/plugins && \
+  rm -rf *.hpi && \
+  for f in * ; do echo "Exploding $f..." && mv "$f" "$f.hpi" ; done;
 
 # Unofficial experimental image, AdoptOpenJDK does not offer official Alpine for JDK8
 FROM adoptopenjdk/openjdk8:jdk8u252-b09-alpine

--- a/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
@@ -11,8 +11,14 @@ ADD setup /jenkinsfile-runner/setup
 ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD pom.xml /jenkinsfile-runner/pom.xml
 RUN cd /jenkinsfile-runner && mvn clean package
+# Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \
+# Delete HPI files and use the archive directories instead
+RUN echo "Optimizing plugins..." && \
+  cd /jenkinsfile-runner/vanilla-package/target/plugins && \
+  rm -rf *.hpi && \
+  for f in * ; do echo "Exploding $f..." && mv "$f" "$f.hpi" ; done;
 
 FROM adoptopenjdk:8u262-b10-jdk-hotspot
 RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This patch uses the plugin manager trick when the Plugin Manager loads plugins from `foo.hpi` directories without needing an archive. It allows to reduce the size of the vanilla image by almost 80Mb, because we bundle the exploded files only. As a bonus point, startup time would be slightly improved