### PR TITLE
Optimize the memory footprint by not keeping stacktraces in AntClassLoader

### DIFF
--- a/setup/src/main/java/hudson/ClassNotFoundExceptionNoStackTrace.java
+++ b/setup/src/main/java/hudson/ClassNotFoundExceptionNoStackTrace.java
@@ -1,0 +1,13 @@
+package hudson;
+
+public class ClassNotFoundExceptionNoStackTrace extends ClassNotFoundException {
+
+    public ClassNotFoundExceptionNoStackTrace(String className) {
+        super(className);
+    }
+
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+}

--- a/setup/src/main/java/hudson/JFRPluginStrategy.java
+++ b/setup/src/main/java/hudson/JFRPluginStrategy.java
@@ -1,0 +1,695 @@
+package hudson;
+
+import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.model.Hudson;
+import hudson.util.CyclicGraphDetector;
+import hudson.util.IOUtils;
+import hudson.util.MaskingClassLoader;
+import jenkins.ClassLoaderReflectionToolkit;
+import jenkins.ExtensionFilter;
+import jenkins.plugins.DetachedPluginsUtil;
+import jenkins.util.AntWithFindResourceClassLoader;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.tools.ant.AntClassLoader;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.taskdefs.Expand;
+import org.apache.tools.ant.taskdefs.Zip;
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.PatternSet;
+import org.apache.tools.ant.types.Resource;
+import org.apache.tools.ant.types.ZipFileSet;
+import org.apache.tools.ant.types.resources.MappedResourceCollection;
+import org.apache.tools.ant.util.GlobPatternMapper;
+import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.ZipExtraField;
+import org.apache.tools.zip.ZipOutputStream;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static hudson.ClassicPluginStrategy.DISABLE_TRANSFORMER;
+
+
+public class JFRPluginStrategy implements PluginStrategy {
+
+
+    private static final Logger LOGGER = Logger.getLogger(ClassicPluginStrategy.class.getName());
+
+    /**
+     * Filter for jar files.
+     */
+    private static final FilenameFilter JAR_FILTER = new FilenameFilter() {
+        public boolean accept(File dir,String name) {
+            return name.endsWith(".jar");
+        }
+    };
+
+    private PluginManager pluginManager;
+
+    /**
+     * All the plugins eventually delegate this classloader to load core, servlet APIs, and SE runtime.
+     */
+    private final MaskingClassLoader coreClassLoader = new MaskingClassLoader(getClass().getClassLoader());
+
+    public JFRPluginStrategy(PluginManager pluginManager) {
+        this.pluginManager = pluginManager;
+    }
+
+    @Override public String getShortName(File archive) throws IOException {
+        Manifest manifest;
+        if (!archive.exists()) {
+            throw new FileNotFoundException("Failed to load " + archive + ". The file does not exist");
+        } else if (!archive.isFile()) {
+            throw new FileNotFoundException("Failed to load " + archive + ". It is not a file");
+        }
+
+        if (isLinked(archive)) {
+            manifest = loadLinkedManifest(archive);
+        } else {
+            try (JarFile jf = new JarFile(archive, false)) {
+                manifest = jf.getManifest();
+            } catch (IOException ex) {
+                // Mention file name in the exception
+                throw new IOException("Failed to load " + archive, ex);
+            }
+        }
+        return PluginWrapper.computeShortName(manifest, archive.getName());
+    }
+
+    private static boolean isLinked(File archive) {
+        return archive.getName().endsWith(".hpl") || archive.getName().endsWith(".jpl");
+    }
+
+    private static Manifest loadLinkedManifest(File archive) throws IOException {
+        // resolve the .hpl file to the location of the manifest file
+        try {
+            // Locate the manifest
+            String firstLine;
+            try (InputStream manifestHeaderInput = Files.newInputStream(archive.toPath())) {
+                firstLine = IOUtils.readFirstLine(manifestHeaderInput, "UTF-8");
+            } catch (InvalidPathException e) {
+                throw new IOException(e);
+            }
+            //noinspection StatementWithEmptyBody
+            if (firstLine.startsWith("Manifest-Version:")) {
+                // this is the manifest already
+            } else {
+                // indirection
+                archive = resolve(archive, firstLine);
+            }
+
+            // Read the manifest
+            try (InputStream manifestInput = Files.newInputStream(archive.toPath())) {
+                return new Manifest(manifestInput);
+            } catch (InvalidPathException e) {
+                throw new IOException(e);
+            }
+        } catch (IOException e) {
+            throw new IOException("Failed to load " + archive, e);
+        }
+    }
+
+    @Override public PluginWrapper createPluginWrapper(File archive) throws IOException {
+        final Manifest manifest;
+
+        URL baseResourceURL;
+        File expandDir = null;
+        // if .hpi, this is the directory where war is expanded
+
+        boolean isLinked = isLinked(archive);
+        if (isLinked) {
+            manifest = loadLinkedManifest(archive);
+        } else {
+            if (archive.isDirectory()) {// already expanded
+                expandDir = archive;
+            } else {
+                File f = pluginManager.getWorkDir();
+                expandDir =  new File(f == null ? archive.getParentFile() : f, FilenameUtils.getBaseName(archive.getName()));
+                explode(archive, expandDir);
+            }
+
+            File manifestFile = new File(expandDir, PluginWrapper.MANIFEST_FILENAME);
+            if (!manifestFile.exists()) {
+                throw new IOException(
+                        "Plugin installation failed. No manifest at "
+                                + manifestFile);
+            }
+            try (InputStream fin = Files.newInputStream(manifestFile.toPath())) {
+                manifest = new Manifest(fin);
+            } catch (InvalidPathException e) {
+                throw new IOException(e);
+            }
+            String canonicalName = manifest.getMainAttributes().getValue("Short-Name") + ".jpi";
+            if (!archive.getName().equals(canonicalName)) {
+                LOGGER.warning(() -> "encountered " + archive + " under a nonstandard name; expected " + canonicalName);
+            }
+        }
+
+        final Attributes atts = manifest.getMainAttributes();
+
+        // TODO: define a mechanism to hide classes
+        // String export = manifest.getMainAttributes().getValue("Export");
+
+        List<File> paths = new ArrayList<>();
+        if (isLinked) {
+            parseClassPath(manifest, archive, paths, "Libraries", ",");
+            parseClassPath(manifest, archive, paths, "Class-Path", " +"); // backward compatibility
+
+            baseResourceURL = resolve(archive,atts.getValue("Resource-Path")).toURI().toURL();
+        } else {
+            File classes = new File(expandDir, "WEB-INF/classes");
+            if (classes.exists()) { // should not normally happen, due to createClassJarFromWebInfClasses
+                LOGGER.log(Level.WARNING, "Deprecated unpacked classes directory found in {0}", classes);
+                paths.add(classes);
+            }
+            File lib = new File(expandDir, "WEB-INF/lib");
+            File[] libs = lib.listFiles(JAR_FILTER);
+            if (libs != null)
+                paths.addAll(Arrays.asList(libs));
+
+            baseResourceURL = expandDir.toPath().toUri().toURL();
+
+        }
+        File disableFile = new File(archive.getPath() + ".disabled");
+        if (disableFile.exists()) {
+            LOGGER.info("Plugin " + archive.getName() + " is disabled");
+        }
+
+        // compute dependencies
+        List<PluginWrapper.Dependency> dependencies = new ArrayList<>();
+        List<PluginWrapper.Dependency> optionalDependencies = new ArrayList<>();
+        String v = atts.getValue("Plugin-Dependencies");
+        if (v != null) {
+            for (String s : v.split(",")) {
+                PluginWrapper.Dependency d = new PluginWrapper.Dependency(s);
+                if (d.optional) {
+                    optionalDependencies.add(d);
+                } else {
+                    dependencies.add(d);
+                }
+            }
+        }
+
+        fix(atts,optionalDependencies);
+
+        // Register global classpath mask. This is useful for hiding JavaEE APIs that you might see from the container,
+        // such as database plugin for JPA support. The Mask-Classes attribute is insufficient because those classes
+        // also need to be masked by all the other plugins that depend on the database plugin.
+        String masked = atts.getValue("Global-Mask-Classes");
+        if(masked!=null) {
+            for (String pkg : masked.trim().split("[ \t\r\n]+"))
+                coreClassLoader.add(pkg);
+        }
+
+        ClassLoader dependencyLoader = new DependencyClassLoader(coreClassLoader, archive, Util.join(dependencies,optionalDependencies));
+        dependencyLoader = getBaseClassLoader(atts, dependencyLoader);
+
+        return new PluginWrapper(pluginManager, archive, manifest, baseResourceURL,
+                createClassLoader(paths, dependencyLoader, atts), disableFile, dependencies, optionalDependencies);
+    }
+
+    private void fix(Attributes atts, List<PluginWrapper.Dependency> optionalDependencies) {
+        String pluginName = atts.getValue("Short-Name");
+
+        String jenkinsVersion = atts.getValue("Jenkins-Version");
+        if (jenkinsVersion==null)
+            jenkinsVersion = atts.getValue("Hudson-Version");
+
+        for (PluginWrapper.Dependency d : DetachedPluginsUtil.getImpliedDependencies(pluginName, jenkinsVersion)) {
+            LOGGER.fine(() -> "implied dep " + pluginName + " → " + d.shortName);
+            pluginManager.considerDetachedPlugin(d.shortName);
+            optionalDependencies.add(d);
+        }
+    }
+
+    /**
+     * @see DetachedPluginsUtil#getImpliedDependencies(String, String)
+     *
+     * @deprecated since 2.163
+     */
+    @Deprecated
+    @NonNull
+    public static List<PluginWrapper.Dependency> getImpliedDependencies(String pluginName, String jenkinsVersion) {
+        return DetachedPluginsUtil.getImpliedDependencies(pluginName, jenkinsVersion);
+    }
+
+    @Deprecated
+    protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent) throws IOException {
+        return createClassLoader( paths, parent, null );
+    }
+
+    /**
+     * Creates the classloader that can load all the specified jar files and delegate to the given parent.
+     */
+    protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
+        if (atts != null) {
+            String usePluginFirstClassLoader = atts.getValue( "PluginFirstClassLoader" );
+            if (Boolean.parseBoolean( usePluginFirstClassLoader )) {
+                PluginFirstClassLoader classLoader = new PluginFirstClassLoader();
+                classLoader.setParentFirst( false );
+                classLoader.setParent( parent );
+                classLoader.addPathFiles( paths );
+                return classLoader;
+            }
+        }
+
+        AntClassLoader2 classLoader = new AntClassLoader2(parent);
+        classLoader.addPathFiles(paths);
+        return classLoader;
+    }
+
+    /**
+     * Computes the classloader that takes the class masking into account.
+     *
+     * <p>
+     * This mechanism allows plugins to have their own versions for libraries that core bundles.
+     */
+    private ClassLoader getBaseClassLoader(Attributes atts, ClassLoader base) {
+        String masked = atts.getValue("Mask-Classes");
+        if(masked!=null)
+            base = new MaskingClassLoader(base, masked.trim().split("[ \t\r\n]+"));
+        return base;
+    }
+
+    public void initializeComponents(PluginWrapper plugin) {
+    }
+
+    public <T> List<ExtensionComponent<T>> findComponents(Class<T> type, Hudson hudson) {
+
+        List<ExtensionFinder> finders;
+        if (type==ExtensionFinder.class) {
+            // Avoid infinite recursion of using ExtensionFinders to find ExtensionFinders
+            finders = Collections.singletonList(new ExtensionFinder.Sezpoz());
+        } else {
+            finders = hudson.getExtensionList(ExtensionFinder.class);
+        }
+
+        /*
+         * See ExtensionFinder#scout(Class, Hudson) for the dead lock issue and what this does.
+         */
+        if (LOGGER.isLoggable(Level.FINER))
+            LOGGER.log(Level.FINER, "Scout-loading ExtensionList: "+type, new Throwable());
+        for (ExtensionFinder finder : finders) {
+            finder.scout(type, hudson);
+        }
+
+        List<ExtensionComponent<T>> r = Lists.newArrayList();
+        for (ExtensionFinder finder : finders) {
+            try {
+                r.addAll(finder.find(type, hudson));
+            } catch (AbstractMethodError e) {
+                // backward compatibility
+                for (T t : finder.findExtensions(type, hudson))
+                    r.add(new ExtensionComponent<>(t));
+            }
+        }
+
+        List<ExtensionComponent<T>> filtered = Lists.newArrayList();
+        for (ExtensionComponent<T> e : r) {
+            if (ExtensionFilter.isAllowed(type,e))
+                filtered.add(e);
+        }
+
+        return filtered;
+    }
+
+    public void load(PluginWrapper wrapper) throws IOException {
+        // override the context classloader. This no longer makes sense,
+        // but it is left for the backward compatibility
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(wrapper.classLoader);
+        try {
+            String className = wrapper.getPluginClass();
+            if(className==null) {
+                // use the default dummy instance
+                wrapper.setPlugin(new Plugin.DummyImpl());
+            } else {
+                try {
+                    Class<?> clazz = wrapper.classLoader.loadClass(className);
+                    Object o = clazz.newInstance();
+                    if(!(o instanceof Plugin)) {
+                        throw new IOException(className+" doesn't extend from hudson.Plugin");
+                    }
+                    wrapper.setPlugin((Plugin) o);
+                } catch (LinkageError | ClassNotFoundException e) {
+                    throw new IOException("Unable to load " + className + " from " + wrapper.getShortName(),e);
+                } catch (IllegalAccessException | InstantiationException e) {
+                    throw new IOException("Unable to create instance of " + className + " from " + wrapper.getShortName(),e);
+                }
+            }
+
+            // initialize plugin
+            try {
+                Plugin plugin = wrapper.getPlugin();
+                plugin.setServletContext(pluginManager.context);
+                startPlugin(wrapper);
+            } catch(Throwable t) {
+                // gracefully handle any error in plugin.
+                throw new IOException("Failed to initialize",t);
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
+    }
+
+    public void startPlugin(PluginWrapper plugin) throws Exception {
+        plugin.getPlugin().start();
+    }
+
+    @Override
+    public void updateDependency(PluginWrapper depender, PluginWrapper dependee) {
+        DependencyClassLoader classLoader = findAncestorDependencyClassLoader(depender.classLoader);
+        if (classLoader != null) {
+            classLoader.updateTransientDependencies();
+            LOGGER.log(Level.INFO, "Updated dependency of {0}", depender.getShortName());
+        }
+    }
+
+    private DependencyClassLoader findAncestorDependencyClassLoader(ClassLoader classLoader)
+    {
+        for (; classLoader != null; classLoader = classLoader.getParent()) {
+            if (classLoader instanceof DependencyClassLoader) {
+                return (DependencyClassLoader)classLoader;
+            }
+
+            if (classLoader instanceof AntClassLoader) {
+                // AntClassLoaders hold parents not only as AntClassLoader#getParent()
+                // but also as AntClassLoader#getConfiguredParent()
+                DependencyClassLoader ret = findAncestorDependencyClassLoader(
+                        ((AntClassLoader)classLoader).getConfiguredParent()
+                );
+                if (ret != null) {
+                    return ret;
+                }
+            }
+        }
+        return null;
+    }
+
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Administrator action installing a plugin, which could do far worse.")
+    private static File resolve(File base, String relative) {
+        File rel = new File(relative);
+        if(rel.isAbsolute())
+            return rel;
+        else
+            return new File(base.getParentFile(),relative);
+    }
+
+    private static void parseClassPath(Manifest manifest, File archive, List<File> paths, String attributeName, String separator) throws IOException {
+        String classPath = manifest.getMainAttributes().getValue(attributeName);
+        if(classPath==null) return; // attribute not found
+        for (String s : classPath.split(separator)) {
+            File file = resolve(archive, s);
+            if(file.getName().contains("*")) {
+                // handle wildcard
+                FileSet fs = new FileSet();
+                File dir = file.getParentFile();
+                fs.setDir(dir);
+                fs.setIncludes(file.getName());
+                for( String included : fs.getDirectoryScanner(new Project()).getIncludedFiles() ) {
+                    paths.add(new File(dir,included));
+                }
+            } else {
+                if(!file.exists())
+                    throw new IOException("No such file: "+file);
+                paths.add(file);
+            }
+        }
+    }
+
+    /**
+     * Explodes the plugin into a directory, if necessary.
+     */
+    private static void explode(File archive, File destDir) throws IOException {
+        destDir.mkdirs();
+
+        // timestamp check
+        File explodeTime = new File(destDir,".timestamp2");
+        if(explodeTime.exists() && explodeTime.lastModified()==archive.lastModified())
+            return; // no need to expand
+
+        // delete the contents so that old files won't interfere with new files
+        Util.deleteRecursive(destDir);
+
+        try {
+            Project prj = new Project();
+            unzipExceptClasses(archive, destDir, prj);
+            createClassJarFromWebInfClasses(archive, destDir, prj);
+        } catch (BuildException x) {
+            throw new IOException("Failed to expand " + archive,x);
+        }
+
+        try {
+            new FilePath(explodeTime).touch(archive.lastModified());
+        } catch (InterruptedException e) {
+            throw new AssertionError(e); // impossible
+        }
+    }
+
+    /**
+     * Repackage classes directory into a jar file to make it remoting friendly.
+     * The remoting layer can cache jar files but not class files.
+     */
+    private static void createClassJarFromWebInfClasses(File archive, File destDir, Project prj) throws IOException {
+        File classesJar = new File(destDir, "WEB-INF/lib/classes.jar");
+
+        ZipFileSet zfs = new ZipFileSet();
+        zfs.setProject(prj);
+        zfs.setSrc(archive);
+        zfs.setIncludes("WEB-INF/classes/");
+
+        MappedResourceCollection mapper = new MappedResourceCollection();
+        mapper.add(zfs);
+
+        GlobPatternMapper gm = new GlobPatternMapper();
+        gm.setFrom("WEB-INF/classes/*");
+        gm.setTo("*");
+        mapper.add(gm);
+
+        final long dirTime = archive.lastModified();
+        // this ZipOutputStream is reused and not created for each directory
+        try (ZipOutputStream wrappedZOut = new ZipOutputStream(new NullOutputStream()) {
+            @Override
+            public void putNextEntry(ZipEntry ze) throws IOException {
+                ze.setTime(dirTime+1999);   // roundup
+                super.putNextEntry(ze);
+            }
+        }) {
+            Zip z = new Zip() {
+                /**
+                 * Forces the fixed timestamp for directories to make sure
+                 * classes.jar always get a consistent checksum.
+                 */
+                protected void zipDir(Resource dir, ZipOutputStream zOut, String vPath,
+                                      int mode, ZipExtraField[] extra)
+                        throws IOException {
+                    // use wrappedZOut instead of zOut
+                    super.zipDir(dir,wrappedZOut,vPath,mode,extra);
+                }
+            };
+            z.setProject(prj);
+            z.setTaskType("zip");
+            classesJar.getParentFile().mkdirs();
+            z.setDestFile(classesJar);
+            z.add(mapper);
+            z.execute();
+        }
+        if (classesJar.isFile()) {
+            LOGGER.log(Level.WARNING, "Created {0}; update plugin to a version created with a newer harness", classesJar);
+        }
+    }
+
+    private static void unzipExceptClasses(File archive, File destDir, Project prj) {
+        Expand e = new Expand();
+        e.setProject(prj);
+        e.setTaskType("unzip");
+        e.setSrc(archive);
+        e.setDest(destDir);
+        PatternSet p = new PatternSet();
+        p.setExcludes("WEB-INF/classes/");
+        e.addPatternset(p);
+        e.execute();
+    }
+
+    /**
+     * Used to load classes from dependency plugins.
+     */
+    final class DependencyClassLoader extends ClassLoader {
+        /**
+         * This classloader is created for this plugin. Useful during debugging.
+         */
+        private final File _for;
+
+        private List<PluginWrapper.Dependency> dependencies;
+
+        /**
+         * Topologically sorted list of transient dependencies.
+         */
+        private volatile List<PluginWrapper> transientDependencies;
+
+        public DependencyClassLoader(ClassLoader parent, File archive, List<PluginWrapper.Dependency> dependencies) {
+            super(parent);
+            this._for = archive;
+            this.dependencies = dependencies;
+        }
+
+        private void updateTransientDependencies() {
+            // This will be recalculated at the next time.
+            transientDependencies = null;
+        }
+
+        private List<PluginWrapper> getTransitiveDependencies() {
+            if (transientDependencies==null) {
+                CyclicGraphDetector<PluginWrapper> cgd = new CyclicGraphDetector<PluginWrapper>() {
+                    @Override
+                    protected List<PluginWrapper> getEdges(PluginWrapper pw) {
+                        List<PluginWrapper> dep = new ArrayList<>();
+                        for (PluginWrapper.Dependency d : pw.getDependencies()) {
+                            PluginWrapper p = pluginManager.getPlugin(d.shortName);
+                            if (p!=null && p.isActive())
+                                dep.add(p);
+                        }
+                        return dep;
+                    }
+                };
+
+                try {
+                    for (PluginWrapper.Dependency d : dependencies) {
+                        PluginWrapper p = pluginManager.getPlugin(d.shortName);
+                        if (p!=null && p.isActive())
+                            cgd.run(Collections.singleton(p));
+                    }
+                } catch (CyclicGraphDetector.CycleDetectedException e) {
+                    throw new AssertionError(e);    // such error should have been reported earlier
+                }
+
+                transientDependencies = cgd.getSorted();
+            }
+            return transientDependencies;
+        }
+
+//        public List<PluginWrapper> getDependencyPluginWrappers() {
+//            List<PluginWrapper> r = new ArrayList<PluginWrapper>();
+//            for (Dependency d : dependencies) {
+//                PluginWrapper w = pluginManager.getPlugin(d.shortName);
+//                if (w!=null)    r.add(w);
+//            }
+//            return r;
+//        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (PluginManager.FAST_LOOKUP) {
+                for (PluginWrapper pw : getTransitiveDependencies()) {
+                    try {
+                        Class<?> c = ClassLoaderReflectionToolkit._findLoadedClass(pw.classLoader, name);
+                        if (c!=null)    return c;
+                        return ClassLoaderReflectionToolkit._findClass(pw.classLoader, name);
+                    } catch (ClassNotFoundException ignored) {
+                        //not found. try next
+                    }
+                }
+            } else {
+                for (PluginWrapper.Dependency dep : dependencies) {
+                    PluginWrapper p = pluginManager.getPlugin(dep.shortName);
+                    if(p!=null) {
+                        try {
+                            return p.classLoader.loadClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            // OK, try next
+                        }
+                    }
+                }
+            }
+
+            throw new ClassNotFoundException(name);
+        }
+
+        @Override
+        @SuppressFBWarnings(value = "DMI_COLLECTION_OF_URLS",
+                justification = "Should not produce network overheads since the URL is local. JENKINS-53793 is a follow-up")
+        protected Enumeration<URL> findResources(String name) throws IOException {
+            HashSet<URL> result = new HashSet<>();
+
+            if (PluginManager.FAST_LOOKUP) {
+                for (PluginWrapper pw : getTransitiveDependencies()) {
+                    Enumeration<URL> urls = ClassLoaderReflectionToolkit._findResources(pw.classLoader, name);
+                    while (urls != null && urls.hasMoreElements())
+                        result.add(urls.nextElement());
+                }
+            } else {
+                for (PluginWrapper.Dependency dep : dependencies) {
+                    PluginWrapper p = pluginManager.getPlugin(dep.shortName);
+                    if (p!=null) {
+                        Enumeration<URL> urls = p.classLoader.getResources(name);
+                        while (urls != null && urls.hasMoreElements())
+                            result.add(urls.nextElement());
+                    }
+                }
+            }
+
+            return Collections.enumeration(result);
+        }
+
+        @Override
+        protected URL findResource(String name) {
+            if (PluginManager.FAST_LOOKUP) {
+                for (PluginWrapper pw : getTransitiveDependencies()) {
+                    URL url = ClassLoaderReflectionToolkit._findResource(pw.classLoader, name);
+                    if (url!=null)    return url;
+                }
+            } else {
+                for (PluginWrapper.Dependency dep : dependencies) {
+                    PluginWrapper p = pluginManager.getPlugin(dep.shortName);
+                    if(p!=null) {
+                        URL url = p.classLoader.getResource(name);
+                        if (url!=null)
+                            return url;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * {@link AntClassLoader} with a few methods exposed, {@link Closeable} support, and {@link org.jenkinsci.bytecode.Transformer} support.
+     */
+    private final class AntClassLoader2 extends AntWithFindResourceClassLoader implements Closeable {
+        private AntClassLoader2(ClassLoader parent) {
+            super(parent, true);
+        }
+
+        @Override
+        protected Class defineClassFromData(File container, byte[] classData, String classname) throws IOException {
+            if (!DISABLE_TRANSFORMER)
+                classData = pluginManager.getCompatibilityTransformer().transform(classname, classData, this);
+            return super.defineClassFromData(container, classData, classname);
+        }
+    }
+
+
+}

--- a/setup/src/main/java/hudson/JFRPluginStrategy.java
+++ b/setup/src/main/java/hudson/JFRPluginStrategy.java
@@ -624,7 +624,7 @@ public class JFRPluginStrategy implements PluginStrategy {
                 }
             }
 
-            throw new ClassNotFoundException(name);
+            throw new ClassNotFoundExceptionNoStackTrace(name);
         }
 
         @Override

--- a/setup/src/main/java/hudson/JFRPluginStrategy.java
+++ b/setup/src/main/java/hudson/JFRPluginStrategy.java
@@ -275,7 +275,7 @@ public class JFRPluginStrategy implements PluginStrategy {
             }
         }
 
-        AntClassLoader2 classLoader = new AntClassLoader2(parent);
+        PatchedAntClassLoader2 classLoader = new PatchedAntClassLoader2(parent);
         classLoader.addPathFiles(paths);
         return classLoader;
     }
@@ -394,11 +394,11 @@ public class JFRPluginStrategy implements PluginStrategy {
                 return (DependencyClassLoader)classLoader;
             }
 
-            if (classLoader instanceof AntClassLoader) {
+            if (classLoader instanceof PatchedAntClassLoader) {
                 // AntClassLoaders hold parents not only as AntClassLoader#getParent()
                 // but also as AntClassLoader#getConfiguredParent()
                 DependencyClassLoader ret = findAncestorDependencyClassLoader(
-                        ((AntClassLoader)classLoader).getConfiguredParent()
+                        ((PatchedAntClassLoader)classLoader).getConfiguredParent()
                 );
                 if (ret != null) {
                     return ret;
@@ -678,8 +678,8 @@ public class JFRPluginStrategy implements PluginStrategy {
     /**
      * {@link AntClassLoader} with a few methods exposed, {@link Closeable} support, and {@link org.jenkinsci.bytecode.Transformer} support.
      */
-    private final class AntClassLoader2 extends AntWithFindResourceClassLoader implements Closeable {
-        private AntClassLoader2(ClassLoader parent) {
+    private final class PatchedAntClassLoader2 extends PatchedAntWithFindResourceClassLoader implements Closeable {
+        private PatchedAntClassLoader2(ClassLoader parent) {
             super(parent, true);
         }
 

--- a/setup/src/main/java/hudson/PatchedAntClassLoader.java
+++ b/setup/src/main/java/hudson/PatchedAntClassLoader.java
@@ -1384,7 +1384,7 @@ public class PatchedAntClassLoader extends ClassLoader implements SubBuildListen
                         + ioe.getMessage() + ")", Project.MSG_VERBOSE);
             }
         }
-        throw new ClassNotFoundException(name);
+        throw new ClassNotFoundExceptionNoStackTrace(name);
     }
 
     /**

--- a/setup/src/main/java/hudson/PatchedAntClassLoader.java
+++ b/setup/src/main/java/hudson/PatchedAntClassLoader.java
@@ -1,0 +1,1584 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package hudson;
+
+import jenkins.telemetry.impl.java11.MissingClassTelemetry;
+import org.apache.tools.ant.BuildEvent;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.SubBuildListener;
+import org.apache.tools.ant.launch.Locator;
+import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.util.CollectionUtils;
+import org.apache.tools.ant.util.FileUtils;
+import org.apache.tools.ant.util.JavaEnvUtils;
+import org.apache.tools.ant.util.LoaderUtils;
+import org.apache.tools.ant.util.ReflectUtil;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
+import java.util.Vector;
+import java.util.jar.Attributes;
+import java.util.jar.Attributes.Name;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Used to load classes within ant with a different classpath from
+ * that used to start ant. Note that it is possible to force a class
+ * into this loader even when that class is on the system classpath by
+ * using the forceLoadClass method. Any subsequent classes loaded by that
+ * class will then use this loader rather than the system class loader.
+ *
+ * <p>
+ * Note that this classloader has a feature to allow loading
+ * in reverse order and for "isolation".
+ * Due to the fact that a number of
+ * methods in java.lang.ClassLoader are final (at least
+ * in java 1.4 getResources) this means that the
+ * class has to fake the given parent.
+ * </p>
+ *
+ */
+@Restricted(NoExternalUse.class)
+public class PatchedAntClassLoader extends ClassLoader implements SubBuildListener {
+
+    private static final FileUtils FILE_UTILS = FileUtils.getFileUtils();
+
+    /**
+     * An enumeration of all resources of a given name found within the
+     * classpath of this class loader. This enumeration is used by the
+     * ClassLoader.findResources method, which is in
+     * turn used by the ClassLoader.getResources method.
+     *
+     * @see PatchedAntClassLoader#findResources(String)
+     * @see java.lang.ClassLoader#getResources(String)
+     */
+    private class ResourceEnumeration implements Enumeration {
+        /**
+         * The name of the resource being searched for.
+         */
+        private String resourceName;
+
+        /**
+         * The index of the next classpath element to search.
+         */
+        private int pathElementsIndex;
+
+        /**
+         * The URL of the next resource to return in the enumeration. If this
+         * field is {@code null} then the enumeration has been completed,
+         * i.e., there are no more elements to return.
+         */
+        private URL nextResource;
+
+        /**
+         * Constructs a new enumeration of resources of the given name found
+         * within this class loader's classpath.
+         *
+         * @param name the name of the resource to search for.
+         */
+        ResourceEnumeration(String name) {
+            this.resourceName = name;
+            this.pathElementsIndex = 0;
+            findNextResource();
+        }
+
+        /**
+         * Indicates whether there are more elements in the enumeration to
+         * return.
+         *
+         * @return {@code true} if there are more elements in the
+         *         enumeration; {@code false} otherwise.
+         */
+        public boolean hasMoreElements() {
+            return (this.nextResource != null);
+        }
+
+        /**
+         * Returns the next resource in the enumeration.
+         *
+         * @return the next resource in the enumeration
+         */
+        public Object nextElement() {
+            URL ret = this.nextResource;
+            if (ret == null) {
+                throw new NoSuchElementException();
+            }
+            findNextResource();
+            return ret;
+        }
+
+        /**
+         * Locates the next resource of the correct name in the classpath and
+         * sets {@code nextResource} to the URL of that resource. If no
+         * more resources can be found, {@code nextResource} is set to
+         * {@code null}.
+         */
+        private void findNextResource() {
+            URL url = null;
+            while ((pathElementsIndex < pathComponents.size()) && (url == null)) {
+                try {
+                    File pathComponent = pathComponents.get(pathElementsIndex);
+                    url = getResourceURL(pathComponent, this.resourceName);
+                    pathElementsIndex++;
+                } catch (BuildException e) {
+                    // ignore path elements which are not valid relative to the
+                    // project
+                }
+            }
+            this.nextResource = url;
+        }
+    }
+
+    /**
+     * The size of buffers to be used in this classloader.
+     */
+    private static final int BUFFER_SIZE = 8192;
+
+    /**
+     * Number of array elements in a test array of strings
+     */
+    private static final int NUMBER_OF_STRINGS = 256;
+
+    /**
+     * The components of the classpath that the classloader searches
+     * for classes.
+     */
+    private ArrayList<File> pathComponents = new ArrayList<>();
+
+    /**
+     * The project to which this class loader belongs.
+     */
+    private Project project;
+
+    /**
+     * Indicates whether the parent class loader should be
+     * consulted before trying to load with this class loader.
+     */
+    private boolean parentFirst = true;
+
+    /**
+     * These are the package roots that are to be loaded by the parent class
+     * loader regardless of whether the parent class loader is being searched
+     * first or not.
+     */
+    private Vector systemPackages = new Vector();
+
+    /**
+     * These are the package roots that are to be loaded by this class loader
+     * regardless of whether the parent class loader is being searched first
+     * or not.
+     */
+    private Vector loaderPackages = new Vector();
+
+    /**
+     * Whether or not this classloader will ignore the base
+     * classloader if it can't find a class.
+     *
+     * @see #setIsolated(boolean)
+     */
+    private boolean ignoreBase = false;
+
+    /**
+     * The parent class loader, if one is given or can be determined.
+     */
+    private ClassLoader parent = null;
+
+    /**
+     * A hashtable of zip files opened by the classloader (File to JarFile).
+     */
+    private Hashtable jarFiles = new Hashtable();
+
+    /** Static map of jar file/time to manifest class-path entries */
+    private static Map/*<String,String>*/ pathMap = Collections.synchronizedMap(new HashMap());
+
+    /**
+     * The context loader saved when setting the thread's current
+     * context loader.
+     */
+    private ClassLoader savedContextLoader = null;
+
+    /**
+     * Whether or not the context loader is currently saved.
+     */
+    private boolean isContextLoaderSaved = false;
+
+    /**
+     * Create an Ant ClassLoader for a given project, with
+     * a parent classloader and an initial classpath.
+     * @since Ant 1.7.
+     * @param parent the parent for this classloader.
+     * @param project The project to which this classloader is to
+     *                belong.
+     * @param classpath The classpath to use to load classes.
+     */
+    public PatchedAntClassLoader(ClassLoader parent, Project project, Path classpath) {
+        super(parent);  // KK patch for JENKINS-21579
+        setParent(parent);
+        setClassPath(classpath);
+        setProject(project);
+    }
+
+    /**
+     * Create an Ant Class Loader
+     */
+    public PatchedAntClassLoader() {
+        setParent(null);
+    }
+
+    /**
+     * Creates a classloader for the given project using the classpath given.
+     *
+     * @param project The project to which this classloader is to belong.
+     *                Must not be {@code null}.
+     * @param classpath The classpath to use to load the classes.  This
+     *                is combined with the system classpath in a manner
+     *                determined by the value of ${build.sysclasspath}.
+     *                May be {@code null}, in which case no path
+     *                elements are set up to start with.
+     */
+    public PatchedAntClassLoader(Project project, Path classpath) {
+        setParent(null);
+        setProject(project);
+        setClassPath(classpath);
+    }
+
+    /**
+     * Creates a classloader for the given project using the classpath given.
+     *
+     * @param parent The parent classloader to which unsatisfied loading
+     *               attempts are delegated. May be {@code null},
+     *               in which case the classloader which loaded this
+     *               class is used as the parent.
+     * @param project The project to which this classloader is to belong.
+     *                Must not be {@code null}.
+     * @param classpath the classpath to use to load the classes.
+     *                  May be {@code null}, in which case no path
+     *                  elements are set up to start with.
+     * @param parentFirst If {@code true}, indicates that the parent
+     *                    classloader should be consulted  before trying to
+     *                    load the a class through this loader.
+     */
+    public PatchedAntClassLoader(
+            ClassLoader parent, Project project, Path classpath, boolean parentFirst) {
+        this(project, classpath);
+        if (parent != null) {
+            setParent(parent);
+        }
+        setParentFirst(parentFirst);
+        addJavaLibraries();
+    }
+
+    /**
+     * Creates a classloader for the given project using the classpath given.
+     *
+     * @param project The project to which this classloader is to belong.
+     *                Must not be {@code null}.
+     * @param classpath The classpath to use to load the classes. May be
+     *                  {@code null}, in which case no path
+     *                  elements are set up to start with.
+     * @param parentFirst If {@code true}, indicates that the parent
+     *                    classloader should be consulted before trying to
+     *                    load the a class through this loader.
+     */
+    public PatchedAntClassLoader(Project project, Path classpath, boolean parentFirst) {
+        this(null, project, classpath, parentFirst);
+    }
+
+    /**
+     * Creates an empty class loader. The classloader should be configured
+     * with path elements to specify where the loader is to look for
+     * classes.
+     *
+     * @param parent The parent classloader to which unsatisfied loading
+     *               attempts are delegated. May be {@code null},
+     *               in which case the classloader which loaded this
+     *               class is used as the parent.
+     * @param parentFirst If {@code true}, indicates that the parent
+     *                    classloader should be consulted before trying to
+     *                    load the a class through this loader.
+     */
+    public PatchedAntClassLoader(ClassLoader parent, boolean parentFirst) {
+        super(parent);  // KK patch for JENKINS-21579
+        setParent(parent);
+        project = null;
+        this.parentFirst = parentFirst;
+    }
+
+    /**
+     * Set the project associated with this class loader
+     *
+     * @param project the project instance
+     */
+    public void setProject(Project project) {
+        this.project = project;
+        if (project != null) {
+            project.addBuildListener(this);
+        }
+    }
+
+    /**
+     * Set the classpath to search for classes to load. This should not be
+     * changed once the classloader starts to server classes
+     *
+     * @param classpath the search classpath consisting of directories and
+     *        jar/zip files.
+     */
+    public void setClassPath(Path classpath) {
+        pathComponents.clear();
+        if (classpath != null) {
+            Path actualClasspath = classpath.concatSystemClasspath("ignore");
+            String[] pathElements = actualClasspath.list();
+            for (String pathElement : pathElements) {
+                try {
+                    addPathElement(pathElement);
+                } catch (BuildException e) {
+                    // ignore path elements which are invalid
+                    // relative to the project
+                }
+            }
+        }
+    }
+
+    /**
+     * Set the parent for this class loader. This is the class loader to which
+     * this class loader will delegate to load classes
+     *
+     * @param parent the parent class loader.
+     */
+    public void setParent(ClassLoader parent) {
+        this.parent = parent == null ? PatchedAntClassLoader.class.getClassLoader() : parent;
+    }
+
+    /**
+     * Control whether class lookup is delegated to the parent loader first
+     * or after this loader. Use with extreme caution. Setting this to
+     * false violates the class loader hierarchy and can lead to Linkage errors
+     *
+     * @param parentFirst if true, delegate initial class search to the parent
+     *                    classloader.
+     */
+    public void setParentFirst(boolean parentFirst) {
+        this.parentFirst = parentFirst;
+    }
+
+    /**
+     * Logs a message through the project object if one has been provided.
+     *
+     * @param message The message to log.
+     *                Should not be {@code null}.
+     *
+     * @param priority The logging priority of the message.
+     */
+    protected void log(String message, int priority) {
+        if (project != null) {
+            project.log(message, priority);
+        }
+    }
+
+    /**
+     * Sets the current thread's context loader to this classloader, storing
+     * the current loader value for later resetting.
+     */
+    public void setThreadContextLoader() {
+        if (isContextLoaderSaved) {
+            throw new BuildException("Context loader has not been reset");
+        }
+        if (LoaderUtils.isContextLoaderAvailable()) {
+            savedContextLoader = LoaderUtils.getContextClassLoader();
+            ClassLoader loader = this;
+            if (project != null && "only".equals(project.getProperty("build.sysclasspath"))) {
+                loader = this.getClass().getClassLoader();
+            }
+            LoaderUtils.setContextClassLoader(loader);
+            isContextLoaderSaved = true;
+        }
+    }
+
+    /**
+     * Resets the current thread's context loader to its original value.
+     */
+    public void resetThreadContextLoader() {
+        if (LoaderUtils.isContextLoaderAvailable() && isContextLoaderSaved) {
+            LoaderUtils.setContextClassLoader(savedContextLoader);
+            savedContextLoader = null;
+            isContextLoaderSaved = false;
+        }
+    }
+
+
+    /**
+     * Adds an element to the classpath to be searched.
+     *
+     * @param pathElement The path element to add. Must not be
+     *                    {@code null}.
+     *
+     * @exception BuildException if the given path element cannot be resolved
+     *                           against the project.
+     */
+    public void addPathElement(String pathElement) throws BuildException {
+        File pathComponent = project != null ? project.resolveFile(pathElement) : new File(
+                pathElement);
+        try {
+            addPathFile(pathComponent);
+        } catch (IOException e) {
+            throw new BuildException(e);
+        }
+    }
+
+    /**
+     * Add a path component.
+     * This simply adds the file, unlike addPathElement
+     * it does not open jar files and load files from
+     * their CLASSPATH entry in the manifest file.
+     * @param file the jar file or directory to add.
+     */
+    public void addPathComponent(File file) {
+        if (pathComponents.contains(file)) {
+            return;
+        }
+        pathComponents.add(file);
+    }
+
+    /**
+     * Add a file to the path.
+     * Reads the manifest, if available, and adds any additional class path jars
+     * specified in the manifest.
+     *
+     * @param pathComponent the file which is to be added to the path for
+     *                      this class loader
+     *
+     * @throws IOException if data needed from the file cannot be read.
+     */
+    protected void addPathFile(File pathComponent) throws IOException {
+        if (!pathComponents.contains(pathComponent)) {
+            pathComponents.add(pathComponent);
+        }
+        if (pathComponent.isDirectory()) {
+            return;
+        }
+
+        String absPathPlusTimeAndLength = pathComponent.getAbsolutePath()
+                + pathComponent.lastModified() + "-" + pathComponent.length();
+        String classpath = (String) pathMap.get(absPathPlusTimeAndLength);
+        if (classpath == null) {
+            try (JarFile jarFile = new JarFile(pathComponent)) {
+                Manifest manifest = jarFile.getManifest();
+                if (manifest == null) {
+                    return;
+                }
+                classpath = manifest.getMainAttributes()
+                        .getValue(Attributes.Name.CLASS_PATH);
+            }
+            if (classpath == null) {
+                classpath = "";
+            }
+            pathMap.put(absPathPlusTimeAndLength, classpath);
+        }
+
+        if (!"".equals(classpath)) {
+            URL baseURL = FILE_UTILS.getFileURL(pathComponent);
+            StringTokenizer st = new StringTokenizer(classpath);
+            while (st.hasMoreTokens()) {
+                String classpathElement = st.nextToken();
+                URL libraryURL = new URL(baseURL, classpathElement);
+                if (!libraryURL.getProtocol().equals("file")) {
+                    log("Skipping jar library " + classpathElement
+                                    + " since only relative URLs are supported by this" + " loader",
+                            Project.MSG_VERBOSE);
+                    continue;
+                }
+                String decodedPath = Locator.decodeUri(libraryURL.getFile());
+                File libraryFile = new File(decodedPath);
+                if (libraryFile.exists() && !isInPath(libraryFile)) {
+                    addPathFile(libraryFile);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the classpath this classloader will consult.
+     *
+     * @return the classpath used for this classloader, with elements
+     *         separated by the path separator for the system.
+     */
+    public String getClasspath() {
+        StringBuilder sb = new StringBuilder();
+        boolean firstPass = true;
+        for (File pathComponent : pathComponents) {
+            if (!firstPass) {
+                sb.append(System.getProperty("path.separator"));
+            } else {
+                firstPass = false;
+            }
+            sb.append(pathComponent.getAbsolutePath());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Sets whether this classloader should run in isolated mode. In
+     * isolated mode, classes not found on the given classpath will
+     * not be referred to the parent class loader but will cause a
+     * ClassNotFoundException.
+     *
+     * @param isolated Whether or not this classloader should run in
+     *                 isolated mode.
+     */
+    public synchronized void setIsolated(boolean isolated) {
+        ignoreBase = isolated;
+    }
+
+    /**
+     * Forces initialization of a class in a JDK 1.1 compatible, albeit hacky
+     * way.
+     *
+     * @param theClass The class to initialize.
+     *                 Must not be {@code null}.
+     *
+     * @deprecated since 1.6.x.
+     *             Use Class.forName with initialize=true instead.
+     */
+    @Deprecated
+    public static void initializeClass(Class theClass) {
+        // ***HACK*** We ask the VM to create an instance
+        // by voluntarily providing illegal arguments to force
+        // the VM to run the class' static initializer, while
+        // at the same time not running a valid constructor.
+
+        final Constructor[] cons = theClass.getDeclaredConstructors();
+        //At least one constructor is guaranteed to be there, but check anyway.
+        if (cons != null) {
+            if (cons.length > 0 && cons[0] != null) {
+                final String[] strs = new String[NUMBER_OF_STRINGS];
+                try {
+                    cons[0].newInstance((Object[]) strs);
+                    // Expecting an exception to be thrown by this call:
+                    // IllegalArgumentException: wrong number of Arguments
+                } catch (Exception e) {
+                    // Ignore - we are interested only in the side
+                    // effect - that of getting the static initializers
+                    // invoked.  As we do not want to call a valid
+                    // constructor to get this side effect, an
+                    // attempt is made to call a hopefully
+                    // invalid constructor - come on, nobody
+                    // would have a constructor that takes in
+                    // 256 String arguments ;-)
+                    // (In fact, they can't - according to JVM spec
+                    // section 4.10, the number of method parameters is limited
+                    // to 255 by the definition of a method descriptor.
+                    // Constructors count as methods here.)
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds a package root to the list of packages which must be loaded on the
+     * parent loader.
+     *
+     * All subpackages are also included.
+     *
+     * @param packageRoot The root of all packages to be included.
+     *                    Should not be {@code null}.
+     */
+    public void addSystemPackageRoot(String packageRoot) {
+        systemPackages.addElement(packageRoot + (packageRoot.endsWith(".") ? "" : "."));
+    }
+
+    /**
+     * Adds a package root to the list of packages which must be loaded using
+     * this loader.
+     *
+     * All subpackages are also included.
+     *
+     * @param packageRoot The root of all packages to be included.
+     *                    Should not be {@code null}.
+     */
+    public void addLoaderPackageRoot(String packageRoot) {
+        loaderPackages.addElement(packageRoot + (packageRoot.endsWith(".") ? "" : "."));
+    }
+
+    /**
+     * Loads a class through this class loader even if that class is available
+     * on the parent classpath.
+     *
+     * This ensures that any classes which are loaded by the returned class
+     * will use this classloader.
+     *
+     * @param classname The name of the class to be loaded.
+     *                  Must not be {@code null}.
+     *
+     * @return the required Class object
+     *
+     * @exception ClassNotFoundException if the requested class does not exist
+     *                                   on this loader's classpath.
+     */
+    public Class forceLoadClass(String classname) throws ClassNotFoundException {
+        log("force loading " + classname, Project.MSG_DEBUG);
+
+        Class theClass = findLoadedClass(classname);
+
+        if (theClass == null) {
+            theClass = findClass(classname);
+        }
+        return theClass;
+    }
+
+    /**
+     * Loads a class through this class loader but defer to the parent class
+     * loader.
+     *
+     * This ensures that instances of the returned class will be compatible
+     * with instances which have already been loaded on the parent
+     * loader.
+     *
+     * @param classname The name of the class to be loaded.
+     *                  Must not be {@code null}.
+     *
+     * @return the required Class object
+     *
+     * @exception ClassNotFoundException if the requested class does not exist
+     * on this loader's classpath.
+     */
+    public Class forceLoadSystemClass(String classname) throws ClassNotFoundException {
+        log("force system loading " + classname, Project.MSG_DEBUG);
+
+        Class theClass = findLoadedClass(classname);
+
+        if (theClass == null) {
+            theClass = findBaseClass(classname);
+        }
+        return theClass;
+    }
+
+    /**
+     * Returns a stream to read the requested resource name.
+     *
+     * @param name The name of the resource for which a stream is required.
+     *             Must not be {@code null}.
+     *
+     * @return a stream to the required resource or {@code null} if the
+     *         resource cannot be found on the loader's classpath.
+     */
+    public InputStream getResourceAsStream(String name) {
+        InputStream resourceStream = null;
+        if (isParentFirst(name)) {
+            resourceStream = loadBaseResource(name);
+        }
+        if (resourceStream != null) {
+            log("ResourceStream for " + name
+                    + " loaded from parent loader", Project.MSG_DEBUG);
+        } else {
+            resourceStream = loadResource(name);
+            if (resourceStream != null) {
+                log("ResourceStream for " + name
+                        + " loaded from ant loader", Project.MSG_DEBUG);
+            }
+        }
+        if (resourceStream == null && !isParentFirst(name)) {
+            if (ignoreBase) {
+                resourceStream = getRootLoader() == null ? null : getRootLoader().getResourceAsStream(name);
+            } else {
+                resourceStream = loadBaseResource(name);
+            }
+            if (resourceStream != null) {
+                log("ResourceStream for " + name + " loaded from parent loader",
+                        Project.MSG_DEBUG);
+            }
+        }
+        if (resourceStream == null) {
+            log("Couldn't load ResourceStream for " + name, Project.MSG_DEBUG);
+        }
+        return resourceStream;
+    }
+
+    /**
+     * Returns a stream to read the requested resource name from this loader.
+     *
+     * @param name The name of the resource for which a stream is required.
+     *             Must not be {@code null}.
+     *
+     * @return a stream to the required resource or {@code null} if
+     *         the resource cannot be found on the loader's classpath.
+     */
+    private InputStream loadResource(String name) {
+        // we need to search the components of the path to see if we can
+        // find the class we want.
+        for (File pathComponent : pathComponents) {
+            InputStream stream = getResourceStream(pathComponent, name);
+            if (stream != null) {
+                return stream;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds a system resource (which should be loaded from the parent
+     * classloader).
+     *
+     * @param name The name of the system resource to load.
+     *             Must not be {@code null}.
+     *
+     * @return a stream to the named resource, or {@code null} if
+     *         the resource cannot be found.
+     */
+    private InputStream loadBaseResource(String name) {
+        return parent == null ? super.getResourceAsStream(name) : parent.getResourceAsStream(name);
+    }
+
+    @FunctionalInterface
+    private interface Converter<T> {
+        T convert(@NonNull JarFile jarFile, @NonNull JarEntry entry) throws IOException;
+    }
+
+    @CheckForNull
+    private <T> T storeAndConvert(JarFile jarFile, File file, String resourceName, Converter<T> converter) throws IOException {
+        if (jarFile == null) {
+            if (file.exists()) {
+                jarFile = new JarFile(file);
+                jarFiles.put(file, jarFile);
+            } else {
+                return null;
+            }
+            //to eliminate a race condition, retrieve the entry
+            //that is in the hash table under that filename
+            jarFile = (JarFile) jarFiles.get(file);
+        }
+        JarEntry entry = jarFile.getJarEntry(resourceName);
+        if (entry == null)
+            return null;
+        return converter.convert(jarFile, entry);
+    }
+
+    /**
+     * Returns an inputstream to a given resource in the given file which may
+     * either be a directory or a zip file.
+     *
+     * @param file the file (directory or jar) in which to search for the
+     *             resource. Must not be {@code null}.
+     * @param resourceName The name of the resource for which a stream is
+     *                     required. Must not be {@code null}.
+     *
+     * @return a stream to the required resource or {@code null} if
+     *         the resource cannot be found in the given file.
+     */
+    private InputStream getResourceStream(File file, String resourceName) {
+        try {
+            JarFile jarFile = (JarFile) jarFiles.get(file);
+            if (jarFile == null && file.isDirectory()) {
+                File resource = new File(file, resourceName);
+                if (resource.exists()) {
+                    return Files.newInputStream(resource.toPath());
+                }
+            } else {
+                return storeAndConvert(jarFile, file, resourceName, JarFile::getInputStream);
+            }
+        } catch (Exception e) {
+            log("Ignoring Exception " + e.getClass().getName() + ": " + e.getMessage()
+                    + " reading resource " + resourceName + " from " + file, Project.MSG_VERBOSE);
+        }
+        return null;
+    }
+
+    /**
+     * Tests whether or not the parent classloader should be checked for a
+     * resource before this one. If the resource matches both the "use parent
+     * classloader first" and the "use this classloader first" lists, the latter
+     * takes priority.
+     *
+     * @param resourceName
+     *            The name of the resource to check. Must not be
+     *            {@code null}.
+     *
+     * @return whether or not the parent classloader should be checked for a
+     *         resource before this one is.
+     */
+    private boolean isParentFirst(String resourceName) {
+        // default to the global setting and then see
+        // if this class belongs to a package which has been
+        // designated to use a specific loader first
+        // (this one or the parent one)
+
+        // TODO shouldn't this always return false in isolated mode?
+
+        boolean useParentFirst = parentFirst;
+
+        for (Enumeration e = systemPackages.elements(); e.hasMoreElements();) {
+            String packageName = (String) e.nextElement();
+            if (resourceName.startsWith(packageName)) {
+                useParentFirst = true;
+                break;
+            }
+        }
+        for (Enumeration e = loaderPackages.elements(); e.hasMoreElements();) {
+            String packageName = (String) e.nextElement();
+            if (resourceName.startsWith(packageName)) {
+                useParentFirst = false;
+                break;
+            }
+        }
+        return useParentFirst;
+    }
+
+    /**
+     * Used for isolated resource searching.
+     * @return the root classloader of AntClassLoader.
+     */
+    private ClassLoader getRootLoader() {
+        ClassLoader ret = getClass().getClassLoader();
+        while (ret != null && ret.getParent() != null) {
+            ret = ret.getParent();
+        }
+        return ret;
+    }
+
+    /**
+     * Finds the resource with the given name. A resource is
+     * some data (images, audio, text, etc) that can be accessed by class
+     * code in a way that is independent of the location of the code.
+     *
+     * @param name The name of the resource for which a stream is required.
+     *             Must not be {@code null}.
+     *
+     * @return a URL for reading the resource, or {@code null} if the
+     *         resource could not be found or the caller doesn't have
+     *         adequate privileges to get the resource.
+     */
+    public URL getResource(String name) {
+        // we need to search the components of the path to see if
+        // we can find the class we want.
+        URL url = null;
+        if (isParentFirst(name)) {
+            url = parent == null ? super.getResource(name) : parent.getResource(name);
+        }
+        if (url != null) {
+            log("Resource " + name + " loaded from parent loader", Project.MSG_DEBUG);
+        } else {
+            // try and load from this loader if the parent either didn't find
+            // it or wasn't consulted.
+            url = getUrl(pathComponents, name);
+        }
+        if (url == null && !isParentFirst(name)) {
+            // this loader was first but it didn't find it - try the parent
+            if (ignoreBase) {
+                url = getRootLoader() == null ? null : getRootLoader().getResource(name);
+            } else {
+                url = parent == null ? super.getResource(name) : parent.getResource(name);
+            }
+            if (url != null) {
+                log("Resource " + name + " loaded from parent loader", Project.MSG_DEBUG);
+            }
+        }
+        if (url == null) {
+            log("Couldn't load Resource " + name, Project.MSG_DEBUG);
+        }
+        return url;
+    }
+
+    /**
+     * Finds a matching file by iterating pathComponents.
+     *
+     * @param pathComponents Path to a folder, split into the individual folder names
+     * @param name File to find
+     * @return Url to found object
+     */
+    @CheckForNull
+    protected URL getUrl(Iterable<File> pathComponents, String name) {
+        URL url = null;
+        for (File pathComponent : pathComponents) {
+            url = getResourceURL(pathComponent, name);
+            if (url != null) {
+                log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
+                break;
+            }
+        }
+        return url;
+    }
+
+    /**
+     * Finds all the resources with the given name. A resource is some
+     * data (images, audio, text, etc) that can be accessed by class
+     * code in a way that is independent of the location of the code.
+     *
+     * <p>Would override getResources if that wasn't final in Java
+     * 1.4.</p>
+     *
+     * @since Ant 1.8.0
+     */
+    public Enumeration/*<URL>*/ getNamedResources(String name)
+            throws IOException {
+        return findResources(name, false);
+    }
+
+    /**
+     * Returns an enumeration of URLs representing all the resources with the
+     * given name by searching the class loader's classpath.
+     *
+     * @param name The resource name to search for.
+     *             Must not be {@code null}.
+     * @return an enumeration of URLs for the resources
+     * @exception IOException if I/O errors occurs (can't happen)
+     */
+    protected Enumeration/*<URL>*/ findResources(String name) throws IOException {
+        return findResources(name, true);
+    }
+
+    /**
+     * Returns an enumeration of URLs representing all the resources with the
+     * given name by searching the class loader's classpath.
+     *
+     * @param name The resource name to search for.
+     *             Must not be {@code null}.
+     * @param parentHasBeenSearched whether ClassLoader.this.parent
+     * has been searched - will be true if the method is (indirectly)
+     * called from ClassLoader.getResources
+     * @return an enumeration of URLs for the resources
+     * @exception IOException if I/O errors occurs (can't happen)
+     */
+    protected Enumeration/*<URL>*/ findResources(String name,
+                                                 boolean parentHasBeenSearched)
+            throws IOException {
+        Enumeration/*<URL>*/ mine = new ResourceEnumeration(name);
+        Enumeration/*<URL>*/ base;
+        if (parent != null && (!parentHasBeenSearched || parent != getParent())) {
+            // Delegate to the parent:
+            base = parent.getResources(name);
+            // Note: could cause overlaps in case
+            // ClassLoader.this.parent has matches and
+            // parentHasBeenSearched is true
+        } else {
+            // ClassLoader.this.parent is already delegated to for example from
+            // ClassLoader.getResources, no need:
+            base = new CollectionUtils.EmptyEnumeration();
+        }
+        if (isParentFirst(name)) {
+            // Normal case.
+            return CollectionUtils.append(base, mine);
+        }
+        if (ignoreBase) {
+            return getRootLoader() == null ? mine : CollectionUtils.append(mine, getRootLoader()
+                    .getResources(name));
+        }
+        // parent last:
+        return CollectionUtils.append(mine, base);
+    }
+
+    /**
+     * Returns the URL of a given resource in the given file which may
+     * either be a directory or a zip file.
+     *
+     * @param file The file (directory or jar) in which to search for
+     *             the resource. Must not be {@code null}.
+     * @param resourceName The name of the resource for which a stream
+     *                     is required. Must not be {@code null}.
+     *
+     * @return a stream to the required resource or {@code null} if the
+     *         resource cannot be found in the given file object.
+     */
+    protected URL getResourceURL(File file, String resourceName) {
+        try {
+            JarFile jarFile = (JarFile) jarFiles.get(file);
+            if (jarFile == null && file.isDirectory()) {
+                File resource = new File(file, resourceName);
+
+                if (resource.exists()) {
+                    try {
+                        return FILE_UTILS.getFileURL(resource);
+                    } catch (MalformedURLException ex) {
+                        return null;
+                    }
+                }
+            } else {
+                return storeAndConvert(jarFile, file, resourceName, (jar, entry) -> {
+                    try {
+                        return new URL("jar:" + FILE_UTILS.getFileURL(file) + "!/" + entry);
+                    } catch (MalformedURLException ex) {
+                        return null;
+                    }
+                });
+            }
+        } catch (Exception e) {
+            String msg = "Unable to obtain resource from " + file + ": ";
+            log(msg + e, Project.MSG_WARN);
+            System.err.println(msg);
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Loads a class with this class loader.
+     *
+     * This class attempts to load the class in an order determined by whether
+     * or not the class matches the system/loader package lists, with the
+     * loader package list taking priority. If the classloader is in isolated
+     * mode, failure to load the class in this loader will result in a
+     * ClassNotFoundException.
+     *
+     * @param classname The name of the class to be loaded.
+     *                  Must not be {@code null}.
+     * @param resolve {@code true} if all classes upon which this class
+     *                depends are to be loaded.
+     *
+     * @return the required Class object
+     *
+     * @exception ClassNotFoundException if the requested class does not exist
+     * on the system classpath (when not in isolated mode) or this loader's
+     * classpath.
+     */
+    protected synchronized Class loadClass(String classname, boolean resolve)
+            throws ClassNotFoundException {
+        // 'sync' is needed - otherwise 2 threads can load the same class
+        // twice, resulting in LinkageError: duplicated class definition.
+        // findLoadedClass avoids that, but without sync it won't work.
+
+        Class theClass = findLoadedClass(classname);
+        if (theClass != null) {
+            return theClass;
+        }
+
+        //Surround the former logic with a try-catch to report missing class exceptions via Java11 telemetry
+        try {
+            if (isParentFirst(classname)) {
+                try {
+                    theClass = findBaseClass(classname);
+                    log("Class " + classname + " loaded from parent loader " + "(parentFirst)",
+                            Project.MSG_DEBUG);
+                } catch (ClassNotFoundException cnfe) {
+                    theClass = findClass(classname);
+                    log("Class " + classname + " loaded from ant loader " + "(parentFirst)",
+                            Project.MSG_DEBUG);
+                }
+            } else {
+                try {
+                    theClass = findClass(classname);
+                    log("Class " + classname + " loaded from ant loader", Project.MSG_DEBUG);
+                } catch (ClassNotFoundException cnfe) {
+                    if (ignoreBase) {
+                        throw cnfe;
+                    }
+                    theClass = findBaseClass(classname);
+                    log("Class " + classname + " loaded from parent loader", Project.MSG_DEBUG);
+                }
+            }
+        } catch (ClassNotFoundException cnfe) {
+            //To catch CNFE thrown from this.getClass().getClassLoader().loadClass(classToLoad); from a plugin step or
+            //a plugin page
+            MissingClassTelemetry.reportException(classname, cnfe);
+            throw cnfe;
+        }
+        if (resolve) {
+            resolveClass(theClass);
+        }
+        return theClass;
+    }
+
+    /**
+     * Converts the class dot notation to a filesystem equivalent for
+     * searching purposes.
+     *
+     * @param classname The class name in dot format (eg java.lang.Integer).
+     *                  Must not be {@code null}.
+     *
+     * @return the classname in filesystem format (eg java/lang/Integer.class)
+     */
+    private String getClassFilename(String classname) {
+        return classname.replace('.', '/') + ".class";
+    }
+
+    /**
+     * Define a class given its bytes
+     *
+     * @param container the container from which the class data has been read
+     *                  may be a directory or a jar/zip file.
+     *
+     * @param classData the bytecode data for the class
+     * @param classname the name of the class
+     *
+     * @return the Class instance created from the given data
+     *
+     * @throws IOException if the class data cannot be read.
+     */
+    protected Class defineClassFromData(File container, byte[] classData, String classname)
+            throws IOException {
+        definePackage(container, classname);
+        ProtectionDomain currentPd = Project.class.getProtectionDomain();
+        String classResource = getClassFilename(classname);
+        CodeSource src = new CodeSource(FILE_UTILS.getFileURL(container),
+                getCertificates(container,
+                        classResource));
+        ProtectionDomain classesPd =
+                new ProtectionDomain(src, currentPd.getPermissions(),
+                        this,
+                        currentPd.getPrincipals());
+        return defineClass(classname, classData, 0, classData.length,
+                classesPd);
+    }
+
+    /**
+     * Define the package information associated with a class.
+     *
+     * @param container the file containing the class definition.
+     * @param className the class name of for which the package information
+     *        is to be determined.
+     *
+     * @exception IOException if the package information cannot be read from the
+     *            container.
+     */
+    protected void definePackage(File container, String className) throws IOException {
+        int classIndex = className.lastIndexOf('.');
+        if (classIndex == -1) {
+            return;
+        }
+        String packageName = className.substring(0, classIndex);
+        if (getPackage(packageName) != null) {
+            // already defined
+            return;
+        }
+        // define the package now
+        Manifest manifest = getJarManifest(container);
+
+        if (manifest == null) {
+            definePackage(packageName, null, null, null, null, null, null, null);
+        } else {
+            definePackage(container, packageName, manifest);
+        }
+    }
+
+    /**
+     * Get the manifest from the given jar, if it is indeed a jar and it has a
+     * manifest
+     *
+     * @param container the File from which a manifest is required.
+     *
+     * @return the jar's manifest or null is the container is not a jar or it
+     *         has no manifest.
+     *
+     * @exception IOException if the manifest cannot be read.
+     */
+    private Manifest getJarManifest(File container) throws IOException {
+        if (container.isDirectory()) {
+            return null;
+        }
+        JarFile jarFile = (JarFile) jarFiles.get(container);
+        if (jarFile == null) {
+            return null;
+        }
+        return jarFile.getManifest();
+    }
+
+    /**
+     * Get the certificates for a given jar entry, if it is indeed a jar.
+     *
+     * @param container the File from which to read the entry
+     * @param entry the entry of which the certificates are requested
+     *
+     * @return the entry's certificates or null is the container is
+     *         not a jar or it has no certificates.
+     *
+     * @exception IOException if the manifest cannot be read.
+     */
+    private Certificate[] getCertificates(File container, String entry)
+            throws IOException {
+        if (container.isDirectory()) {
+            return null;
+        }
+        JarFile jarFile = (JarFile) jarFiles.get(container);
+        if (jarFile == null) {
+            return null;
+        }
+        JarEntry ent = jarFile.getJarEntry(entry);
+        return ent == null ? null : ent.getCertificates();
+    }
+
+    /**
+     * Define the package information when the class comes from a
+     * jar with a manifest
+     *
+     * @param container the jar file containing the manifest
+     * @param packageName the name of the package being defined.
+     * @param manifest the jar's manifest
+     */
+    protected void definePackage(File container, String packageName, Manifest manifest) {
+        String sectionName = packageName.replace('.', '/') + "/";
+
+        String specificationTitle = null;
+        String specificationVendor = null;
+        String specificationVersion = null;
+        String implementationTitle = null;
+        String implementationVendor = null;
+        String implementationVersion = null;
+        String sealedString = null;
+        URL sealBase = null;
+
+        Attributes sectionAttributes = manifest.getAttributes(sectionName);
+        if (sectionAttributes != null) {
+            specificationTitle = sectionAttributes.getValue(Name.SPECIFICATION_TITLE);
+            specificationVendor = sectionAttributes.getValue(Name.SPECIFICATION_VENDOR);
+            specificationVersion = sectionAttributes.getValue(Name.SPECIFICATION_VERSION);
+            implementationTitle = sectionAttributes.getValue(Name.IMPLEMENTATION_TITLE);
+            implementationVendor = sectionAttributes.getValue(Name.IMPLEMENTATION_VENDOR);
+            implementationVersion = sectionAttributes.getValue(Name.IMPLEMENTATION_VERSION);
+            sealedString = sectionAttributes.getValue(Name.SEALED);
+        }
+        Attributes mainAttributes = manifest.getMainAttributes();
+        if (mainAttributes != null) {
+            if (specificationTitle == null) {
+                specificationTitle = mainAttributes.getValue(Name.SPECIFICATION_TITLE);
+            }
+            if (specificationVendor == null) {
+                specificationVendor = mainAttributes.getValue(Name.SPECIFICATION_VENDOR);
+            }
+            if (specificationVersion == null) {
+                specificationVersion = mainAttributes.getValue(Name.SPECIFICATION_VERSION);
+            }
+            if (implementationTitle == null) {
+                implementationTitle = mainAttributes.getValue(Name.IMPLEMENTATION_TITLE);
+            }
+            if (implementationVendor == null) {
+                implementationVendor = mainAttributes.getValue(Name.IMPLEMENTATION_VENDOR);
+            }
+            if (implementationVersion == null) {
+                implementationVersion = mainAttributes.getValue(Name.IMPLEMENTATION_VERSION);
+            }
+            if (sealedString == null) {
+                sealedString = mainAttributes.getValue(Name.SEALED);
+            }
+        }
+        if (sealedString != null && sealedString.equalsIgnoreCase("true")) {
+            try {
+                sealBase = new URL(FileUtils.getFileUtils().toURI(container.getAbsolutePath()));
+            } catch (MalformedURLException e) {
+                // ignore
+            }
+        }
+        definePackage(packageName, specificationTitle, specificationVersion, specificationVendor,
+                implementationTitle, implementationVersion, implementationVendor, sealBase);
+    }
+
+    /**
+     * Reads a class definition from a stream.
+     *
+     * @param stream The stream from which the class is to be read.
+     *               Must not be {@code null}.
+     * @param classname The name of the class in the stream.
+     *                  Must not be {@code null}.
+     * @param container the file or directory containing the class.
+     *
+     * @return the Class object read from the stream.
+     *
+     * @exception IOException if there is a problem reading the class from the
+     * stream.
+     * @exception SecurityException if there is a security problem while
+     * reading the class from the stream.
+     */
+    private Class getClassFromStream(InputStream stream, String classname, File container)
+            throws IOException, SecurityException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int bytesRead = -1;
+        byte[] buffer = new byte[BUFFER_SIZE];
+
+        while ((bytesRead = stream.read(buffer, 0, BUFFER_SIZE)) != -1) {
+            baos.write(buffer, 0, bytesRead);
+        }
+        byte[] classData = baos.toByteArray();
+        return defineClassFromData(container, classData, classname);
+    }
+
+    /**
+     * Searches for and load a class on the classpath of this class loader.
+     *
+     * @param name The name of the class to be loaded. Must not be
+     *             {@code null}.
+     *
+     * @return the required Class object
+     *
+     * @exception ClassNotFoundException if the requested class does not exist
+     *                                   on this loader's classpath.
+     */
+    public Class findClass(String name) throws ClassNotFoundException {
+        log("Finding class " + name, Project.MSG_DEBUG);
+        return findClassInComponents(name);
+    }
+
+    /**
+     * Indicate if the given file is in this loader's path
+     *
+     * @param component the file which is to be checked
+     *
+     * @return true if the file is in the class path
+     */
+    protected boolean isInPath(File component) {
+        return pathComponents.contains(component);
+    }
+
+    /**
+     * Finds a class on the given classpath.
+     *
+     * @param name The name of the class to be loaded. Must not be
+     *             {@code null}.
+     *
+     * @return the required Class object
+     *
+     * @exception ClassNotFoundException if the requested class does not exist
+     * on this loader's classpath.
+     */
+    private Class findClassInComponents(String name)
+            throws ClassNotFoundException {
+        // we need to search the components of the path to see if
+        // we can find the class we want.
+        String classFilename = getClassFilename(name);
+        for (File pathComponent : pathComponents) {
+            try (final InputStream stream = getResourceStream(pathComponent, classFilename)) {
+                if (stream != null) {
+                    log("Loaded from " + pathComponent + " "
+                            + classFilename, Project.MSG_DEBUG);
+                    return getClassFromStream(stream, name, pathComponent);
+                }
+            } catch (SecurityException se) {
+                throw se;
+            } catch (IOException ioe) {
+                // ioe.printStackTrace();
+                log("Exception reading component " + pathComponent + " (reason: "
+                        + ioe.getMessage() + ")", Project.MSG_VERBOSE);
+            }
+        }
+        throw new ClassNotFoundException(name);
+    }
+
+    /**
+     * Finds a system class (which should be loaded from the same classloader
+     * as the Ant core).
+     *
+     * For JDK 1.1 compatibility, this uses the findSystemClass method if
+     * no parent classloader has been specified.
+     *
+     * @param name The name of the class to be loaded.
+     *             Must not be {@code null}.
+     *
+     * @return the required Class object
+     *
+     * @exception ClassNotFoundException if the requested class does not exist
+     * on this loader's classpath.
+     */
+    private Class findBaseClass(String name) throws ClassNotFoundException {
+        return parent == null ? findSystemClass(name) : parent.loadClass(name);
+    }
+
+    /**
+     * Cleans up any resources held by this classloader. Any open archive
+     * files are closed.
+     */
+    public synchronized void cleanup() {
+        for (Enumeration e = jarFiles.elements(); e.hasMoreElements();) {
+            JarFile jarFile = (JarFile) e.nextElement();
+            try {
+                jarFile.close();
+            } catch (IOException ioe) {
+                // ignore
+            }
+        }
+        jarFiles = new Hashtable();
+        if (project != null) {
+            project.removeBuildListener(this);
+        }
+        project = null;
+    }
+
+    /**
+     * Gets the parent as has been specified in the constructor or via
+     * setParent.
+     *
+     * @since Ant 1.8.0
+     */
+    public ClassLoader getConfiguredParent() {
+        return parent;
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the buildStarted event
+     */
+    public void buildStarted(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * Cleans up any resources held by this classloader at the end
+     * of a build.
+     *
+     * @param event the buildFinished event
+     */
+    public void buildFinished(BuildEvent event) {
+        cleanup();
+    }
+
+    /**
+     * Cleans up any resources held by this classloader at the end of
+     * a subbuild if it has been created for the subbuild's project
+     * instance.
+     *
+     * @param event the buildFinished event
+     *
+     * @since Ant 1.6.2
+     */
+    public void subBuildFinished(BuildEvent event) {
+        if (event.getProject() == project) {
+            cleanup();
+        }
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the buildStarted event
+     *
+     * @since Ant 1.6.2
+     */
+    public void subBuildStarted(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the targetStarted event
+     */
+    public void targetStarted(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the targetFinished event
+     */
+    public void targetFinished(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the taskStarted event
+     */
+    public void taskStarted(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the taskFinished event
+     */
+    public void taskFinished(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * Empty implementation to satisfy the BuildListener interface.
+     *
+     * @param event the messageLogged event
+     */
+    public void messageLogged(BuildEvent event) {
+        // Not significant for the class loader.
+    }
+
+    /**
+     * add any libraries that come with different java versions
+     * here
+     */
+    public void addJavaLibraries() {
+        Vector packages = JavaEnvUtils.getJrePackages();
+        Enumeration e = packages.elements();
+        while (e.hasMoreElements()) {
+            String packageName = (String) e.nextElement();
+            addSystemPackageRoot(packageName);
+        }
+    }
+
+    /**
+     * Returns a {@code String} representing this loader.
+     * @return the path that this classloader has.
+     */
+    public String toString() {
+        return "AntClassLoader[" + getClasspath() + "]";
+    }
+
+    private static Class subClassToLoad = null;
+    private static final Class[] CONSTRUCTOR_ARGS = new Class[] {
+            ClassLoader.class, Project.class, Path.class, Boolean.TYPE
+    };
+
+    static {
+        if (JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.JAVA_1_5)) {
+            try {
+                subClassToLoad =
+                        Class.forName("org.apache.tools.ant.loader.AntClassLoader5");
+            } catch (ClassNotFoundException e) {
+                // this is Java5 but the installation is lacking our subclass
+            }
+        }
+    }
+
+    /**
+     * Factory method
+     */
+    public static PatchedAntClassLoader newAntClassLoader(ClassLoader parent,
+                                                   Project project,
+                                                   Path path,
+                                                   boolean parentFirst) {
+        if (subClassToLoad != null) {
+            return (PatchedAntClassLoader)
+                    ReflectUtil.newInstance(subClassToLoad,
+                            CONSTRUCTOR_ARGS,
+                            new Object[] {
+                                    parent, project, path, parentFirst
+                            });
+        }
+        return new PatchedAntClassLoader(parent, project, path, parentFirst);
+    }
+
+}

--- a/setup/src/main/java/hudson/PatchedAntWithFindResourceClassLoader.java
+++ b/setup/src/main/java/hudson/PatchedAntWithFindResourceClassLoader.java
@@ -1,0 +1,46 @@
+package hudson;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * As of 1.8.0, {@link org.apache.tools.ant.AntClassLoader} doesn't implement {@link #findResource(String)}
+ * in any meaningful way, which breaks fast lookup. Implement it properly.
+ */
+public class PatchedAntWithFindResourceClassLoader extends PatchedAntClassLoader implements Closeable {
+    private final ArrayList<File> pathComponents;
+
+    public PatchedAntWithFindResourceClassLoader(ClassLoader parent, boolean parentFirst) {
+        super(parent, parentFirst);
+
+        try {
+            Field $pathComponents = PatchedAntClassLoader.class.getDeclaredField("pathComponents");
+            $pathComponents.setAccessible(true);
+            pathComponents = (ArrayList<File>)$pathComponents.get(this);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new Error(e);
+        }
+    }
+
+    public void addPathFiles(Collection<File> paths) throws IOException {
+        for (File f : paths)
+            addPathFile(f);
+    }
+
+    public void close() throws IOException {
+        cleanup();
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        // try and load from this loader if the parent either didn't find
+        // it or wasn't consulted.
+        return getUrl(pathComponents, name);
+    }
+
+}

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/PluginManagerImpl.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/PluginManagerImpl.java
@@ -1,6 +1,8 @@
 package io.jenkins.jenkinsfile.runner;
 
+import hudson.JFRPluginStrategy;
 import hudson.PluginManager;
+import hudson.PluginStrategy;
 
 import javax.servlet.ServletContext;
 import java.io.File;
@@ -18,5 +20,10 @@ class PluginManagerImpl extends PluginManager {
     @Override
     protected Collection<String> loadBundledPlugins() throws Exception {
         return Collections.emptySet();
+    }
+
+    @Override
+    protected PluginStrategy createPluginStrategy() {
+        return new JFRPluginStrategy(this);
     }
 }


### PR DESCRIPTION
These stacktraces are ignored in `ClassicPluginStrategy` anyway... While seemingly minor, this change actually removes more than 200Mb in total heap allocations. I have no access to Intellij IDEA Pro, so no exact metrics. 

* Profiling can be reproduced in https://github.com/jenkinsci/ci.jenkins.io-runner/pull/364

## After

![image](https://user-images.githubusercontent.com/3000480/89842602-6a0bbf00-db76-11ea-9703-d09a3a4b0967.png)


## Before (ignore first seconds of slow initialization)

![image](https://user-images.githubusercontent.com/3000480/89842612-798b0800-db76-11ea-9bda-0699a0dd6d88.png)


Contributes to #241 
