### PR TITLE
Update the Jenkins core from 2.246 to 2.249.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
-    <jenkins.version>2.246</jenkins.version> <!-- Required for module versions in BOM: https://github.com/jenkinsci/jenkins/pull/4854 -->
+    <jenkins.version>2.249.1</jenkins.version>
     <jetty.version>9.4.30.v20200611</jetty.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <findbugs.failOnError>false</findbugs.failOnError>


### PR DESCRIPTION
Updates Jenkinsfile Runner to the recent LTS version. To some extent, it works around the issue with Plugin Installation Manager 2.0.1 when using Docker Pipeline plugin with dependency on 2.248. https://github.com/jenkinsci/plugin-installation-manager-tool/issues/193