### PR TITLE
Update Plugin Installation Manager in Docker images from 0.1-alpha-10 to 2.0.1

### DIFF
--- a/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
@@ -28,7 +28,7 @@ ENV JDK_11 true
 
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 0.1-alpha-10
+ENV JENKINS_PM_VERSION 2.0.1
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/plugin-management-parent-pom-$JENKINS_PM_VERSION/jenkins-plugin-manager-$JENKINS_PM_VERSION.jar
 
 USER root

--- a/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "Optimizing plugins..." && \
 FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 0.1-alpha-10
+ENV JENKINS_PM_VERSION 2.0.1
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/plugin-management-parent-pom-$JENKINS_PM_VERSION/jenkins-plugin-manager-$JENKINS_PM_VERSION.jar
 USER root
 RUN apk add --update --no-cache wget git \

--- a/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "Optimizing plugins..." && \
 FROM adoptopenjdk/openjdk8:jdk8u252-b09-alpine
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 0.1-alpha-10
+ENV JENKINS_PM_VERSION 2.0.1
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/plugin-management-parent-pom-$JENKINS_PM_VERSION/jenkins-plugin-manager-$JENKINS_PM_VERSION.jar
 USER root
 RUN apk add --update --no-cache wget git \

--- a/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 0.1-alpha-10
+ENV JENKINS_PM_VERSION 2.0.1
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/plugin-management-parent-pom-$JENKINS_PM_VERSION/jenkins-plugin-manager-$JENKINS_PM_VERSION.jar
 USER root
 RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \


### PR DESCRIPTION
Pick up many improvements and stability fixes, some breaking changes are implied as well. See https://github.com/jenkinsci/plugin-installation-manager-tool/releases for the full changelog.