### PR TITLE
Allow not specifying any plugin file

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -177,9 +177,7 @@ public class Bootstrap {
 
         if (this.pluginsDir == null) {
             this.pluginsDir = new File("plugins.txt");
-        }
-
-        if (!this.pluginsDir.exists()) {
+        } else if (!this.pluginsDir.exists()) {
             System.err.println("invalid plugins file.");
             System.exit(-1);
         }


### PR DESCRIPTION
It's currently not possible to run without specifying any plugin file.