### PR TITLE
Make sure to pass an absolute directory for JENKINS_HOME

### DIFF
--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -33,8 +33,9 @@ public abstract class JenkinsLauncher extends JenkinsEmbedder {
             if(bootstrap.runHome.list().length > 0) {
                 throw new IllegalArgumentException("--runHome directory is not empty: " + bootstrap.runHome.getAbsolutePath());
             }
+
             //Override homeLoader to use existing directory instead of creating temporary one
-            this.homeLoader = new HudsonHomeLoader.UseExisting(bootstrap.runHome);
+            this.homeLoader = new HudsonHomeLoader.UseExisting(bootstrap.runHome.getAbsoluteFile());
         }
     }
 


### PR DESCRIPTION
Not doing this results in an issue when loading Jenkins in https://github.com/jenkinsci/jenkins/blob/9f48a332e5ff542a32d95caeb02b583e5f043829/core/src/main/java/jenkins/model/Jenkins.java#L3204