### PR TITLE
ChangeLogParser - Use current directory when no directory is explicitly defined

### DIFF
--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/FileSystemSCM.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/FileSystemSCM.java
@@ -44,7 +44,8 @@ public class FileSystemSCM extends SCM {
 
     @Override
     public void checkout(@NonNull Run<?, ?> build, @NonNull Launcher launcher, @NonNull FilePath workspace, @NonNull TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
-        new FilePath(new File(dir)).copyRecursiveTo(new DirScanner.Glob("**/*", null, false), workspace, "**/*");
+        new FilePath(new File(dir == null ? "." : dir))
+                .copyRecursiveTo(new DirScanner.Glob("**/*", null, false), workspace, "**/*");
     }
 
     /**


### PR DESCRIPTION
Use current directory when no directory is explicitly defined

Fixes https://github.com/jenkinsci/jenkinsfile-runner/issues/351

Checked using `../../app/target/appassembler/bin/jenkinsfile-runner -w war -p ../../vanilla-package/target/plugins/` command from `jenkinsfile-runner/demo/declarative-pipeline` directory