### PR TITLE
Git-Maven demo: Switch to the jenkinsfile-runner:maven image pack

### DIFF
--- a/demo/git-maven/README.md
+++ b/demo/git-maven/README.md
@@ -14,9 +14,3 @@ This example is using Jenkinsfile Runner base image for building projects with J
 Image is available on Docker Hub: https://hub.docker.com/r/jenkins4eval/jenkinsfile-runner/tags
 
 Source code for the image is on GitHub: https://github.com/jenkinsci/jenkinsfile-runner-image-packs/tree/main/maven
-
-### Run (without Docker)
-
-```shell
-java -jar ../../app/target/jenkinsfile-runner-standalone.jar -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/jenkins.war -f . 
-```

--- a/demo/git-maven/README.md
+++ b/demo/git-maven/README.md
@@ -1,16 +1,19 @@
 Demo: Git and Maven
 ===================
 
-Demonstrates simple Pipeline which checks out from the Git repository and then runs a Maven build.
-
-| WARNING: This demo is based on the unreleased Vanilla version. Git support will be added in 1.0-beta-12 |
-| --- |
+Demonstrates a simple Pipeline which checks out from the Git repository and then runs a Maven build.
 
 ### Run with Docker
 
 ```
-docker run --rm -v $(pwd)/Jenkinsfile:/workspace/Jenkinsfile jenkins4eval/jenkinsfile-runner:latest
+docker run --rm -v $(pwd)/Jenkinsfile:/workspace/Jenkinsfile jenkins4eval/jenkinsfile-runner:maven
 ```
+
+This example is using Jenkinsfile Runner base image for building projects with Java and Apache Maven.
+
+Image is available on Docker Hub: https://hub.docker.com/r/jenkins4eval/jenkinsfile-runner/tags
+
+Source code for the image is on GitHub: https://github.com/jenkinsci/jenkinsfile-runner-image-packs/tree/main/maven
 
 ### Run (without Docker)
 


### PR DESCRIPTION
Update git-maven to use jenkinsfile-runner:maven

Fixes https://github.com/jenkinsci/jenkinsfile-runner/issues/385
Hope it matches the expectation.

Few concerns:
 - image size is not small
 - pulling a lot of layers

Question:
What happens under the hood when I add:
```bash
    post {
        always {
            junit '**/TEST*.xml'
        }
    }
```
?

In console log I see `Recording test results` when using docker way, with `java -jar` way I see error because of missing plugin. 
But what really happens with archived results, can I get them somewhere or they got deleted because everything runs in temporary directory?