### PR TITLE
Add Code Coverage Publishing to the build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+target/
 app/target/
 bootstrap/target/
 payload-dependencies/target/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ for (int i = 0; i < platforms.size(); ++i) {
 
                     stage('Build') {
                         timeout(60) {
-                            infra.runMaven(['clean', 'verify', '-Dmaven.test.failure.ignore=true', '-Denvironment=test'])
+                            infra.runMaven(['clean', 'verify', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco'])
                         }
                     }
 
@@ -41,6 +41,8 @@ for (int i = 0; i < platforms.size(); ++i) {
                               enabledForFailure: true, aggregatingResults: true, 
                               tools: [java(), spotBugs(pattern: '**/target/spotbugsXml.xml')]
                             )
+
+                            publishCoverage adapters: [jacocoAdapter(mergeToOneReport: true, path: 'vanilla-package/target/site/jacoco-aggregate/*.xml')]
                         }
                     }
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -229,5 +229,39 @@ THE SOFTWARE.
         <module>tests</module>
       </modules>
     </profile>
+    <profile>
+      <id>jacoco</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.6</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+             <execution>
+                <id>report</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- TODO: delete once https://github.com/jenkinsci/pom/pull/138 is integrated -->
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <configuration>
+              <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true ${argLine}</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Adds publishing of Code Coverage reports to Jenkins, with summary reporting to GitHub Checks. It is going to be my Hall of Shame for a while. It is not THAT bad, just a lot of dead code in features we do not really need.

![image](https://user-images.githubusercontent.com/3000480/95587053-da817000-0a41-11eb-8b06-3aaf3c334352.png)

## Jenkins output

![image](https://user-images.githubusercontent.com/3000480/95589571-38fc1d80-0a45-11eb-928c-2801acf09e39.png)


## GitHub Checks

![image](https://user-images.githubusercontent.com/3000480/95589016-714f2c00-0a44-11eb-81a5-5ae29716da08.png)

Could be simplified later if https://github.com/jenkinsci/pom/pull/138 gets merged

