### PR TITLE
Update to the recent Plugin Bill of Materials + Cleanup dependencies which are now supplied by BOM

### DIFF
--- a/packaging-parent-pom/pom.xml
+++ b/packaging-parent-pom/pom.xml
@@ -135,6 +135,18 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>pipeline-as-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -65,13 +65,14 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>pipeline-as-yaml</artifactId>
-      <exclusions>
-        <!-- TODO(oleg_nenashev): guava:13.0.1 in pipeline-model-api 1.7.1 : https://issues.jenkins-ci.org/browse/JENKINS-63123 -->
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.57</version>
+    <version>1.60</version>
     <relativePath />
   </parent>
 
@@ -70,8 +70,8 @@ THE SOFTWARE.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.235.x</artifactId>
-        <version>13</version>
+        <artifactId>bom-2.249.x</artifactId>
+        <version>15</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -89,35 +89,13 @@ THE SOFTWARE.
         <artifactId>support-log-formatter</artifactId>
         <version>1.0</version>
       </dependency>
-      <!-- TODO(oleg-nenashev): Remove after 2.238: https://github.com/jenkinsci/jenkins/pull/4702 -->
-      <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>3.2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>args4j</groupId>
-        <artifactId>args4j</artifactId>
-        <version>2.33</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>version-number</artifactId>
-        <version>1.7</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.9.3</version>
+      <dependency> <!-- Upper bounds prevention between Pipeline as YAML and JCAsC-->
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.11</version>
       </dependency>
 
       <!-- Plugins -->
-      <!--TODO(oleg-nenashev): Remove once in BOM -->
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-multibranch</artifactId>
-        <version>2.22</version>
-      </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pipeline-utility-steps</artifactId>
@@ -127,13 +105,6 @@ THE SOFTWARE.
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>pipeline-as-yaml</artifactId>
         <version>0.12-rc</version>
-      </dependency>
-
-      <!-- Maven plugins -->
-      <dependency>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <version>3.17</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -19,19 +19,6 @@
   <dependencies>
     <!-- Extra Dependencies for Vanilla -->
     <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-definition</artifactId>
-      <!--TODO: Use BOM? -->
-      <version>1.7.2</version>
-      <exclusions>
-        <!-- Upper bounds conflict with the Jenkins Core -->
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-utility-steps</artifactId>
     </dependency>
@@ -39,10 +26,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>pipeline-as-yaml</artifactId>
-    </dependency>  
 
     <!-- Tests -->
     <!-- TODO(oleg_nenashev):


### PR DESCRIPTION
Further cleanup of dependencies in Jenkinsfile Runner so that we have less moving parts.

* Declarative Pipeline and Multi-branch Pipeline use the version supplied by Plugin BOM. Kudos to @chriskilding for https://github.com/jenkinsci/bom/releases/tag/bom-13!
* Declarative Pipeline is no explicitly added as a dependency to JFR Core. It is required for Pipeline as YAML
* Library dependencies are taken from from the 2.249.x Core BOM which is now functional for JFR use-cases

Explicit Jackson 2 API dependency is added as a lame workaround for https://issues.jenkins-ci.org/browse/JENKINS-63990 . It can be removed later one fixed.