### PR TITLE
Use project.version instead of project.parent version in Parent Packaging POM

### DIFF
--- a/packaging-parent-pom/pom.xml
+++ b/packaging-parent-pom/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <jfr.name>jenkinsfile-runner-custom-build</jfr.name>
-    <jfr.version>${project.parent.version}</jfr.version>
+    <jfr.version>${project.version}</jfr.version>
     <!-- Do not package the app using App Assembler (most likely YAGNI, this is for parent POM) -->
     <jfr.skip.packaging>false</jfr.skip.packaging>
     <!-- Do not package the ZIP (Uber Jar is disabled due to https://github.com/jenkinsci/jenkinsfile-runner/issues/350) -->


### PR DESCRIPTION
Otherwise the release fails. If it does not help, will probably start detaching parent POM