### PR TITLE
Resolved managed Maven plugin dependency versioning

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -41,7 +41,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.3.0</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -72,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
         <configuration>
           <resources>
             <resource>

--- a/packaging-parent-pom/pom.xml
+++ b/packaging-parent-pom/pom.xml
@@ -34,7 +34,6 @@
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
-        <version>1.43</version>
         <inherited>false</inherited>
         <executions>
           <execution>


### PR DESCRIPTION
Removed **explicit versioning** to help eliminate conflicts for three **parent managed dependencies**

- [x] org.apache.maven.plugins.**maven-assembly-plugin**

- [x] org.apache.maven.plugins.**maven-resources-plugin**

- [x] org.jvnet.maven-antrun-extended-plugin.**maven-antrun-extended-plugin**
