### PR TITLE
[Github-Actions] fixing depricated env setup

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "::set-output name=project-version::$version"
-          echo "::set-env name=PROJECT_VERSION::$version"
+          echo "PROJECT_VERSION=$version" >> $GITHUB_ENV
       - run: echo $PROJECT_VERSION
       - name: Fetch artifact
         id: fetch-artifact


### PR DESCRIPTION
Github action for publishing artifact has failed as Github deprecated `set-env` and restricted it from executing in Actions.

Action Failed -> https://github.com/jenkinsci/jenkinsfile-runner/runs/1457703982?check_suite_focus=true

![image](https://user-images.githubusercontent.com/26348282/100394152-5c524a80-303c-11eb-9cb1-dbc20a93cf42.png)

Reference: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/