### PR TITLE
Revert the jfr.version support and minimun Jenkins core version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,6 @@ for (int i = 0; i < platforms.size(); ++i) {
 /* Execute our platforms in parallel */
 parallel(branches)
 
-/* FIXME: Custom WAR Packager needs a fix to support the new packaging mode
 stage('Verify Custom WAR Packager demo')
 Map demos = [:]
 demos['cwp'] = {
@@ -73,7 +72,6 @@ demos['cwp'] = {
 }
 
 parallel(demos)
- */
 
 node('docker') {
     ws("container_${branchName}_${buildNumber}") {

--- a/demo/cwp/packager-config.yml
+++ b/demo/cwp/packager-config.yml
@@ -21,7 +21,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.249.1"
+    version: "2.263"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"

--- a/packaging-parent-pom/pom.xml
+++ b/packaging-parent-pom/pom.xml
@@ -13,7 +13,9 @@
 
   <properties>
     <jfr.name>jenkinsfile-runner-custom-build</jfr.name>
-    <jfr.version>1.0-beta-21-SNAPSHOT</jfr.version>
+    <!-- FIXME: Support for this parameter is coming in the next JFR release -->
+    <jfr.version>1.0-beta-20</jfr.version>
+
     <!-- Do not package the app using App Assembler (most likely YAGNI, this is for parent POM) -->
     <jfr.skip.packaging>false</jfr.skip.packaging>
     <!-- Do not package the ZIP (Uber Jar is disabled due to https://github.com/jenkinsci/jenkinsfile-runner/issues/350) -->
@@ -47,7 +49,7 @@
                 <artifactItem>
                   <groupId>io.jenkins.jenkinsfile-runner</groupId>
                   <artifactId>packaging-parent-pom-resources</artifactId>
-                  <version>${jfr.version}</version>
+                  <version>${project.parent.version}</version>
                   <classifier>assembly-zip-config</classifier>
                   <type>xml</type>
                   <outputDirectory>${project.build.directory}/generated-sources/assembly</outputDirectory>
@@ -56,7 +58,7 @@
                 <artifactItem>
                   <groupId>io.jenkins.jenkinsfile-runner</groupId>
                   <artifactId>packaging-parent-pom-resources</artifactId>
-                  <version>${jfr.version}</version>
+                  <version>${project.parent.version}</version>
                   <classifier>jenkins-properties</classifier>
                   <type>xml</type>
                   <outputDirectory>${project.build.directory}/generated-sources/resources-filtered</outputDirectory>
@@ -89,22 +91,22 @@
     <dependency>
       <groupId>io.jenkins.jenkinsfile-runner</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>${jfr.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.jenkinsfile-runner</groupId>
       <artifactId>setup</artifactId>
-      <version>${jfr.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.jenkinsfile-runner</groupId>
       <artifactId>payload</artifactId>
-      <version>${jfr.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.jenkinsfile-runner</groupId>
       <artifactId>payload-dependencies</artifactId>
-      <version>${jfr.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
@@ -123,7 +125,7 @@
     <dependency>
       <groupId>io.jenkins.jenkinsfile-runner</groupId>
       <artifactId>payload-dependencies</artifactId>
-      <version>${jfr.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 
@@ -160,35 +162,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <!-- TODO: Remove after the 1.0 Beta 20 release -->
-      <id>beta-20-development</id>
-      <activation>
-        <file>
-          <exists>${project.build.directory}/../jfr-main-repo-marker.txt</exists>
-        </file>
-      </activation>
-      <properties>
-        <jfr.version>1.0-beta-20-SNAPSHOT</jfr.version>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-release-plugin</artifactId>
-            <configuration>
-              <releaseProfiles>beta-20-development-release-profile</releaseProfiles>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>beta-20-development-release-profile</id>
-      <properties>
-        <jfr.version>1.0-beta-20</jfr.version>
-      </properties>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
-    <jenkins.version>2.263</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <jetty.version>9.4.34.v20201102</jetty.version>
     <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
@@ -72,7 +72,7 @@ THE SOFTWARE.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.263.x</artifactId>
+        <artifactId>bom-2.249.x</artifactId>
         <version>18</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
Reverts some bits of #430 which led to the Docker Build failures and incompatibilities with the Custom WAR Packager. I hoped to rework the release definitions in one release, but it gets too complicated. So I am reverting the `jfr.version` support but keeping all foundation bits which are required to make it happen.

Also reverts #426 for now
