### PR TITLE
Update Plugin Installation Manager in Docker images to 2.2.0

### DIFF
--- a/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
@@ -29,7 +29,7 @@ ENV JDK_11 true
 
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 2.1.3
+ENV JENKINS_PM_VERSION 2.2.0
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
 
 USER root

--- a/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Optimizing plugins..." && \
 FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 2.1.3
+ENV JENKINS_PM_VERSION 2.2.0
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
 
 USER root

--- a/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "Optimizing plugins..." && \
 FROM adoptopenjdk/openjdk8:jdk8u252-b09-alpine
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 2.1.3
+ENV JENKINS_PM_VERSION 2.2.0
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
 
 USER root

--- a/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 2.1.3
+ENV JENKINS_PM_VERSION 2.2.0
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
 
 USER root


### PR DESCRIPTION
Picks up the bugfix in the new Plugin Installation Manager release. Changelog URL: https://github.com/jenkinsci/plugin-installation-manager-tool/releases/tag/2.2.0

CC @timja 
