### PR TITLE
Update Docker builder to Maven 3.6.3, add batch mode flags

### DIFF
--- a/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-hotspot/Dockerfile
@@ -1,6 +1,7 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.5.4 as jenkinsfilerunner-build
+FROM maven:3.6.3-adoptopenjdk-8 as jenkinsfilerunner-build
+RUN apt-get update && apt-get install -y unzip
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD app /jenkinsfile-runner/app
@@ -12,7 +13,7 @@ ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \

--- a/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-11-jre-alpine/Dockerfile
@@ -1,6 +1,7 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.5.4 as jenkinsfilerunner-build
+FROM maven:3.6.3-adoptopenjdk-8 as jenkinsfilerunner-build
+RUN apt-get update && apt-get install -y unzip
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD app /jenkinsfile-runner/app
@@ -12,7 +13,7 @@ ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \

--- a/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-alpine/Dockerfile
@@ -1,6 +1,7 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.5.4 as jenkinsfilerunner-build
+FROM maven:3.6.3-adoptopenjdk-8 as jenkinsfilerunner-build
+RUN apt-get update && apt-get install -y unzip
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD app /jenkinsfile-runner/app
@@ -12,7 +13,7 @@ ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \

--- a/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
+++ b/packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile
@@ -1,7 +1,7 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.5.4 as jenkinsfilerunner-build
-ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
+FROM maven:3.6.3-adoptopenjdk-8 as jenkinsfilerunner-build
+RUN apt-get update && apt-get install -y unzip
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD app /jenkinsfile-runner/app
 ADD bootstrap /jenkinsfile-runner/bootstrap
@@ -12,7 +12,7 @@ ADD vanilla-package /jenkinsfile-runner/vanilla-package
 ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/winstone.jar /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \


### PR DESCRIPTION
Makes the logs cleaner.

Generally speaking, we need to move the build flow out of DockerHub and to build Jenkinsfile Runner on Jenkins and the Jenkins Release infrastructure (or trusted CI).
