### PR TITLE
Refactor Jenkinsfile Runner to support “run” and “cli” subcommands + Deprecate the `--cli` flag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -129,55 +129,101 @@ The exit code reflects the result of the build.
 The `test` directory of this workspace includes a very simple example of Jenkinsfile that can be
 used to demo Jenkinsfile Runner.
 
-=== CLI options
+=== Command Line Interface (CLI)
 
-The executable of Jenkinsfile Runner allows its invocation with these CLI options:
+The Jenkinsfile Runner CLI provides multiple advanced options and commands.
+The The CLI is powered by https://picocli.info/[picocli] and https://github.com/kohsuke/args4j[args4j].
+To execute a command:
 
 ....
- # Usage: jenkinsfile-runner -w [warPath] -p [pluginsDirPath] -f [jenkinsfilePath] [other options]
- --runHome FILE              : Path to the empty Jenkins Home directory to use for
-                               this run. If not specified a temporary directory
-                               will be created. Note that the folder specified via
-                               --runHome will not be disposed after the run.
- --runWorkspace FILE         : Path to the workspace of the run to be used within
-                               the node{} context. It applies to both Jenkins
-                               master and agents (or side containers) if any.
-                               Requires Jenkins 2.119 or above
- -a (--arg)                  : Parameters to be passed to workflow job. Use
-                               multiple -a switches for multiple params
- --cli                       : Launch interactive CLI. (default: false)
- -u (--keep-undefined-parameters) : Keep undefined parameters if set, defaults
-                                    to false.
--f (--file) FILE            : Path to Jenkinsfile (or directory containing a
-                               Jenkinsfile) to run, default to ./Jenkinsfile.
- -ns (--no-sandbox)          : Disable workflow job execution within sandbox
-                               environment
- -p (--plugins) FILE         : plugins required to run pipeline. Either a
-                               plugins.txt file or a /plugins installation
-                               directory. Defaults to plugins.txt.
- -n (--job-name) VAL         : Name of the job the run belongs to, defaults to 'job'
- -b (--build-number) N       : Build number of the run, defaults to 1.
- -c (--cause) VAL            : A string describing the cause of the run.
-                               It will be attached to the build so that it appears in the
-                               build log and becomes available to plug-ins and pipeline steps.
---scm FILE                   : A YAML file defining the SCM and optional credentials to use
-                               with the SCM. If given, the SCM will be checked out into the
-                               workspace automatically in Declarative Pipelines, and will be
-                               available for use with `checkout scm` in Scripted Pipelines.
-                               Note that an SCM cannot currently be used with YAML pipelines.
-                               See link:./docs/using/SCM.adoc[this doc for more details].
- -jv (--jenkins-version) VAL : jenkins version to use (only in case 'warDir' is not
-                               specified). Defaults to latest LTS.
- -w (--jenkins-war) FILE     : Path to exploded Jenkins WAR directory. Depending on packaging,
-                               it may contain the entire WAR file or just resources to be loaded
-                               by the WAR file, for example Groovy hooks or extra libraries.
- -v (--version)              : Display the current version
- -h (--help)                 : Print this help
-
-where `-a`, `-ns`, `--runHome`, `--runWorkspace` and `-jv` are optional.
+ jenkinsfile-runner <command>
 ....
 
-=== Passing parameters
+Supported commands:
+
+* `run` - Runs the Jenkinsfile.
+   This command also runs by default if no subcommands specified.
+* `cli` - Runs interactive https://www.jenkins.io/doc/book/managing/cli/[Jenkins CLI] from where you can access all standard
+   Jenkins commands provided by the Jenkins core and installed plugins:
+   `list-plugins`, `groovy`, `groovysh`, etc.
+* `generate-completion` - Generate bash/zsh completion script for Jenkinsfile Runner.
+* `version` - Shows the Jenkinsfile Runner version.
+* `help` - Displays help information about the specified command.
+
+All commands provide additional CLI arguments which can be accessed through help methods.
+
+==== Jenkins Instance Arguments
+
+Some CLI commands, including `run` require a startup of the Jenkins controller instance within Jenkinsfile Runner.
+
+Common arguments:
+
+* `-w (--jenkins-war) FILE` -
+    Path to exploded Jenkins WAR directory.
+    Depending on packaging, it may contain the entire WAR file or just resources to be loaded
+    by the WAR file, for example Groovy hooks or extra libraries.
+* `-jv (--jenkins-version) VAL` : Jenkins version to use if the WAR file is not specified.
+Defaults to latest LTS.
+* `-p (--plugins) FILE` - Plugins required for the run.
+    Should point to either a `plugins.txt` file or to a /plugins installation directory
+    Defaults to plugins.txt.
+
+Advanced arguments:
+
+* `--jenkinsHome FILE` -
+    Path to the empty Jenkins Home directory to use for this run.
+    If not specified a temporary directory will be created.
+    Note that the specified folder ill not be disposed after the run.
+* `--mirror` - Mirror site to be used to download plugins if `plugins.txt` is specified.
+** NOTE: This option will be reworked in the future once the Plugin Installation Manager tool is integrated
+* `--withInitHooks FILE` - Path to the https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/[Groovy init hooks] directory
+    Hooks can be also passed via `WEB-INF/groovy.init.d/**` directory within the Jenkins WAR resource loader defined in `--jenkins-war`.
+
+==== Running Jenkinsfiles (`run` command)
+
+This is the main command in Jenkinsfile Runner.
+It executes all types of Pipeline definitions supported by Jenkinsfile Runner.
+Usage:
+
+....
+ jenkinsfile-runner run -w [warPath] -p [pluginsDirPath] -f [jenkinsfilePath] [other options]
+....
+
+In addition to Jenkins instance arguments defined above, it supports the following options:
+
+* `-f (--file) FILE` -
+   Path to Jenkinsfile (or directory containing a Jenkinsfile) to run, defaults to ./Jenkinsfile.
+* `-a (--arg)` -
+    Parameters to be passed to the Pipeline job.
+    Use multiple -a switches for multiple params.
+    All parameters will be recognized by Jenkins as String values.
+
+Advanced options:
+
+* `--runWorkspace FILE` -
+  Path to the workspace of the run to be used within the `node{}` context.
+  It applies to both Jenkins controller and agents if any.
+* `-u (--keep-undefined-parameters)` -
+  Keep undefined parameters if set, defaults to false.
+* `-ns (--no-sandbox)`  -
+    Run Pipeline job execution without the sandbox environment and script security checks.
+    Use at your own risk.
+* `-n (--job-name) VAL` -
+    Name of the job the run belongs to, defaults to 'job'
+* `-b (--build-number) N`-
+    Build number of the run, defaults to 1.
+* `-c (--cause) VAL`-
+    A string describing the cause of the run.
+    It will be attached to the build so that it appears in the build log and
+    becomes available to plug-ins and pipeline steps.
+* `--scm FILE` -
+    A YAML file defining the SCM and optional credentials to use with the SCM.
+    If given, the SCM will be checked out into the workspace automatically in Declarative Pipelines,
+    and will be available for use with `checkout scm` in Scripted Pipelines.
+    Note that an SCM cannot currently be used with Pipeline as YAML.
+    See link:./docs/using/SCM.adoc[this doc for more details].
+
+==== Passing parameters
 
 Any parameter values, for parameters defined on workflow job within `parameters` statement,
 can be passed to the Jenkinsfile Runner using `-a` or `--arg` switches in the key=value format.

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -1,34 +1,15 @@
 package io.jenkins.jenkinsfile.runner.bootstrap;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.util.VersionNumber;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
+
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunCLICommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
+import picocli.AutoComplete;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
-import javax.annotation.PostConstruct;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.Callable;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Main entry point for the Jenkinsfile Runner execution.
@@ -36,113 +17,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author Kohsuke Kawaguchi
  * @author Oleg Nenashev
  */
-@Command(name = "jenkinsfile-runner", versionProvider = Bootstrap.VersionProviderImpl.class, sortOptions = false, mixinStandardHelpOptions = true)
+@Command(name = "jenkinsfile-runner", versionProvider = Util.VersionProviderImpl.class, sortOptions = false, mixinStandardHelpOptions = true,
+        subcommands = {RunJenkinsfileCommand.class, RunCLICommand.class, AutoComplete.GenerateCompletion.class, CommandLine.HelpCommand.class})
 public class Bootstrap implements Callable<Integer> {
 
-    public static final long CACHE_EXPIRE = System.currentTimeMillis() - 24 * 3600 * 1000;
-    private static final String WORKSPACES_DIR_SYSTEM_PROPERTY = "jenkins.model.Jenkins.workspacesDir";
-    private static final String DEFAULT_JOBNAME = "job";
-    @CheckForNull
-    private static Properties JFR_PROPERTIES = null;
+    @CommandLine.Mixin
+    public PipelineRunOptions pipelineRunOptions;
 
-    /**
-     * Exploded jenkins.war
-     */
-    @Option(names = { "-w", "--jenkins-war" },
-            description = "Path to exploded jenkins war directory." +
-                    "Depending on packaging, it may contain the entire WAR " +
-                    "or just resources to be loaded by the WAR file, for example Groovy hooks or extra libraries.")
-    @CheckForNull
-    public File warDir;
-
-    /**
-     * Where to load plugins from?
-     */
-    @Option(names = { "-p", "--plugins" },
-            description = "Plugins required to run pipeline. Either a plugins.txt file or a /plugins installation directory. Defaults to plugins.txt")
-    public File pluginsDir;
-
-    /**
-     * Checked out copy of the working space.
-     */
-    @Option(names = { "-f", "--file" },
-            description = "Path to Jenkinsfile or directory containing a Jenkinsfile, defaults to ./Jenkinsfile")
-    public File jenkinsfile;
-
-    /**
-     * Workspace for the Run
-     */
-    @CheckForNull
-    @Option(names = "--runWorkspace",
-            description = "Path to the workspace of the run to be used within the node{} context. " +
-                    "It applies to both Jenkins master and agents (or side containers) if any. " +
-                    "Requires Jenkins 2.119 or above")
-    public File runWorkspace;
-
-    @Option(names = { "-jv", "--jenkins-version"},
-            description = "Jenkins version to use if Jenkins WAR is not specified by --jenkins-war. Defaults to the latest LTS")
-    @CheckForNull
-    public String version;
-
-    @Option(names = { "-m", "--mirror"},
-            description = "mirror site of Jenkins, defaults to http://updates.jenkins.io/download. Get the mirror list from http://mirrors.jenkins-ci.org/status.html")
-    public String mirror;
-
-    /**
-     * Jenkins Home for the Run.
-     */
-    @CheckForNull
-    @Option(names = "--runHome",
-            description = "Path to the empty Jenkins Home directory to use for this run. If not specified a temporary directory will be created. " +
-            "Note that the folder specified via --runHome will not be disposed after the run")
-    public File runHome;
-
-    @CheckForNull
-    @Option(names = "--withInitHooks",
-            description = "Path to a directory containing Groovy Init Hooks to copy into init.groovy.d")
-    public File withInitHooks;
-
-    /**
-     * Job name for the Run.
-     */
-    @Option(names = { "-n", "--job-name"},
-            description = "Name of the job the run belongs to")
-    public String jobName = DEFAULT_JOBNAME;
-
-    /**
-     * Cause of the Run.
-     */
-    @Option(names = { "-c", "--cause"},
-            description = "Cause of the run")
-    public String cause;
-
-    /**
-     * BuildNumber of the Run.
-     */
-    @Option(names = { "-b", "--build-number"},
-            description = "Build number of the run")
-    public int buildNumber = 1;
-
-    @Option(names = { "-a", "--arg" },
-            description = "Parameters to be passed to the build. Use multiple -a switches for multiple params")
-    @CheckForNull
-    public Map<String,String> workflowParameters;
-
-    @Option(names = { "-ns", "--no-sandbox" },
-            description = "Disable workflow job execution within sandbox environment")
-    public boolean noSandBox;
-
-    @Option(names = { "-u", "--keep-undefined-parameters" },
-            description = "Keep undefined parameters if set")
-    public boolean keepUndefinedParameters = false;
-
-    @Option(names = "--cli",
-            description = "Launch interactive CLI") //, forbids = { "-v", "--runWorkspace", "-a", "-ns" })
-    public boolean cliOnly;
-
-    @Option(names = "--scm",
-            description = "YAML definition of the SCM, with optional credentials, to use for the project")
-    public File scm;
+    @CommandLine.Mixin
+    public JenkinsLauncherOptions launcherSettings;
 
     public static void main(String[] args) throws Throwable {
         // break for attaching profiler
@@ -154,254 +37,14 @@ public class Bootstrap implements Callable<Integer> {
         System.exit(exitCode);
     }
 
+    /**
+     * Executes {@link RunJenkinsfileCommand} by default
+     */
     @Override
-    @SuppressFBWarnings("DM_EXIT")
-    public Integer call() {
-        try {
-            postConstruct();
-            return runJenkinsfile();
-        } catch (Throwable ex) {
-            throw new RuntimeException("Unhandled exception", ex);
-        }
-    }
-
-    /**
-     * Directory used as cache for downloaded artifacts.
-     */
-    private File cache = new File(System.getProperty("user.home") + "/.jenkinsfile-runner/");
-
-    @PostConstruct
-    public void postConstruct() throws IOException {
-
-        if (System.getenv("FORCE_JENKINS_CLI") != null) {
-            this.cliOnly = true;
-        }
-
-        // Process the Jenkins version
-        if (this.version != null && this.warDir != null) {
-            System.err.printf("Error: --jenkins-war and --jenkins-version are mutually exclusive options");
-            System.exit(-1);
-        }
-        if (this.version != null && !isVersionSupported()) {
-            System.err.printf("Jenkins version [%s] not supported by this jenkinsfile-runner version (requires %s). %n",
-                    this.version,
-                    getMininumJenkinsVersion());
-            System.exit(-1);
-        }
-        if (warDir == null) {
-            warDir= getJenkinsWar();
-        }
-
-        if (this.jenkinsfile == null) this.jenkinsfile = new File("Jenkinsfile");
-        if (!this.cliOnly && !this.jenkinsfile.exists()) {
-            System.err.println("no Jenkinsfile in current directory.");
-            System.exit(-1);
-        }
-        if (this.jenkinsfile.isDirectory()) this.jenkinsfile = new File(this.jenkinsfile, "Jenkinsfile");
-
-        if (this.pluginsDir == null) {
-            this.pluginsDir = new File("plugins.txt");
-        } else if (!this.pluginsDir.exists()) {
-            System.err.println("invalid plugins file.");
-            System.exit(-1);
-        }
-
-        if (this.pluginsDir.isFile()) {
-
-            File plugins_txt = this.pluginsDir;
-            // This is a plugin list file
-            this.pluginsDir = Files.createTempDirectory("plugins").toFile();
-            for (String line : FileUtils.readLines(plugins_txt, UTF_8)) {
-                String shortname = line;
-                String version = "latest";
-
-                int i = line.indexOf(':');
-                if (i != -1) {
-                    shortname = line.substring(0,i);
-                    version = line.substring(i+1);
-                }
-
-                installPlugin(shortname, version);
-            }
-        }
-
-        if (this.runWorkspace != null){
-            if (System.getProperty(WORKSPACES_DIR_SYSTEM_PROPERTY) != null) {
-                //TODO(oleg_nenashev): It would have been better to keep it other way, but made it as is to retain compatibility
-                System.out.println("Ignoring the --runWorkspace argument, because an explicit System property is set (-D" + WORKSPACES_DIR_SYSTEM_PROPERTY + ")");
-            } else {
-                System.setProperty(WORKSPACES_DIR_SYSTEM_PROPERTY, this.runWorkspace.getAbsolutePath());
-            }
-        }
-
-        if (this.workflowParameters == null){
-            this.workflowParameters = new HashMap<>();
-        }
-        for (Map.Entry<String, String> workflowParameter : this.workflowParameters.entrySet()) {
-            if (workflowParameter.getValue() == null) {
-                workflowParameter.setValue("");
-            }
-        }
-        if (this.cause != null) {
-           this.cause = this.cause.trim();
-           if (this.cause.isEmpty()) this.cause = null;
-        }
-
-        if (this.jobName.isEmpty()) this.jobName = DEFAULT_JOBNAME;
-
-        if (this.keepUndefinedParameters) {
-          System.setProperty("hudson.model.ParametersAction.keepUndefinedParameters", "true");
-        }
-    }
-
-    static class VersionProviderImpl implements CommandLine.IVersionProvider {
-        @Override
-        public String[] getVersion() throws Exception {
-            return new String[] { readJenkinsPomProperty("jfr.version") };
-        }
-    }
-
-    private static String getMininumJenkinsVersion() throws IOException {
-        return readJenkinsPomProperty("minimum.jenkins.version");
-    }
-
-    private boolean isVersionSupported() throws IOException {
-        return new VersionNumber(this.version).isNewerThanOrEqualTo(new VersionNumber(getMininumJenkinsVersion()));
-    }
-
-    private static String readJenkinsPomProperty(String key) throws IOException {
-        if (JFR_PROPERTIES != null) {
-            return JFR_PROPERTIES.getProperty(key);
-        }
-        try (InputStream pomProperties = Bootstrap.class.getResourceAsStream("/jfr.properties")) {
-            Properties props = new Properties();
-            props.load(pomProperties);
-            JFR_PROPERTIES = props;
-            return props.getProperty(key);
-        }
-    }
-
-    private File getJenkinsWar() throws IOException {
-        if (version == null) {
-            System.out.println("No explicit version has been selected, using latest LTS");
-
-            File latestCore = new File(cache, "war/latest.txt");
-            latestCore.getParentFile().mkdirs();
-            // Check once a day
-            if (!latestCore.exists() || latestCore.lastModified() < CACHE_EXPIRE) {
-                FileUtils.copyURLToFile(URI.create("http://updates.jenkins.io/stable/latestCore.txt").toURL(), latestCore);
-            }
-            version = FileUtils.readFileToString(latestCore, StandardCharsets.US_ASCII);
-        }
-
-        System.out.printf("Running pipeline on jenkins %s%n", version);
-
-        File war = new File(cache, String.format("war/%s/jenkins-war-%s.war", version, version));
-        if (!war.exists()) {
-            war.getParentFile().mkdirs();
-            final URL url = new URL(getMirrorURL(String.format("http://updates.jenkins.io/download/war/%s/jenkins.war", version)));
-            System.out.printf("Downloading jenkins %s...%n", version);
-            FileUtils.copyURLToFile(url, war);
-        }
-
-        return war;
-    }
-
-    private void installPlugin(String shortname, String version) throws IOException {
-
-        final File install = new File(pluginsDir, shortname + ".jpi");
-        File plugin = new File(cache, String.format("plugins/%s/%s-%s.hpi", shortname, shortname, version));
-        if (!plugin.exists() || ("latest".equals(version) && plugin.lastModified() < CACHE_EXPIRE) ) {
-            plugin.getParentFile().mkdirs();
-            final URL url = new URL(getMirrorURL(String.format("https://updates.jenkins.io/download/plugins/%s/%s/%s.hpi", shortname, version, shortname)));
-            System.out.printf("Downloading jenkins plugin %s (%s)...%n", shortname, version);
-            FileUtils.copyURLToFile(url, plugin);
-        }
-
-        Files.createSymbolicLink(install.toPath(), plugin.toPath());
-    }
-
-    private String getMirrorURL(String url) {
-        if (this.mirror == null || "".equals(this.mirror.trim())) {
-            return url;
-        }
-
-        return url.replace("https://updates.jenkins.io/download", this.mirror);
-    }
-
-    public int runJenkinsfile() throws Throwable {
-        String appClassName = "io.jenkins.jenkinsfile.runner.App";
-        if (hasClass(appClassName)) {
-            Class<?> c = Class.forName(appClassName);
-            return  ((IApp) c.newInstance()).run(this);
-        }
-
-        // Explode war if necessary
-        String warPath = warDir.getAbsolutePath();
-        if(FilenameUtils.getExtension(warPath).equals("war") && new File(warPath).isFile()) {
-            System.out.println("Exploding," + warPath +  "this might take some time.");
-            warDir = Util.explodeWar(warPath);
-        }
-
-        ClassLoader jenkins = createJenkinsWarClassLoader();
-        ClassLoader setup = createSetupClassLoader(jenkins);
-
-        Thread.currentThread().setContextClassLoader(setup);    // or should this be 'jenkins'?
-
-        try {
-            Class<?> c = setup.loadClass(appClassName);
-            return ((IApp) c.newInstance()).run(this);
-        } catch (ClassNotFoundException e) {
-            if (setup instanceof URLClassLoader) {
-                throw new ClassNotFoundException(e.getMessage() + " not found in " + getAppRepo() + ","
-                        + new File(warDir, "WEB-INF/lib") + " " + Arrays.toString(((URLClassLoader) setup).getURLs()),
-                        e);
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    public ClassLoader createJenkinsWarClassLoader() throws PrivilegedActionException {
-        return AccessController.doPrivileged((PrivilegedExceptionAction<ClassLoader>) () -> new ClassLoaderBuilder(new SideClassLoader(getPlatformClassloader()))
-                .collectJars(new File(warDir, "WEB-INF/lib"))
-                // servlet API needs to be visible to jenkins.war
-                .collectJars(new File(getAppRepo(), "javax/servlet"))
-                .make());
-    }
-
-    public ClassLoader createSetupClassLoader(ClassLoader jenkins) throws IOException {
-        return new ClassLoaderBuilder(jenkins)
-                .collectJars(getAppRepo())
-                .make();
-    }
-
-    /**
-     * In JDK 11, platform classes are not accessible by default but through the platform classloader.
-     */
-    private ClassLoader getPlatformClassloader() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        if (isPostJava8()) {
-            return (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
-        }
-
-        return null;
-    }
-
-    private static boolean isPostJava8() {
-        String javaVersion = System.getProperty("java.version");
-        return !javaVersion.startsWith("1.");
-    }
-
-    public boolean hasClass(String className) {
-        try  {
-            Class.forName(className);
-            return true;
-        }  catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
-
-    public File getAppRepo() {
-        return new File(System.getProperty("app.repo"));
+    public Integer call() throws IllegalStateException {
+        RunJenkinsfileCommand command = new RunJenkinsfileCommand();
+        command.launcherOptions = launcherSettings;
+        command.pipelineRunOptions = pipelineRunOptions;
+        return command.call();
     }
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -5,6 +5,7 @@ import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunCLICommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.VersionCommand;
 import picocli.AutoComplete;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -18,7 +19,7 @@ import java.util.concurrent.Callable;
  * @author Oleg Nenashev
  */
 @Command(name = "jenkinsfile-runner", versionProvider = Util.VersionProviderImpl.class, sortOptions = false, mixinStandardHelpOptions = true,
-        subcommands = {RunJenkinsfileCommand.class, RunCLICommand.class, AutoComplete.GenerateCompletion.class, CommandLine.HelpCommand.class})
+        subcommands = {RunJenkinsfileCommand.class, RunCLICommand.class, AutoComplete.GenerateCompletion.class, VersionCommand.class, CommandLine.HelpCommand.class})
 public class Bootstrap implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/IApp.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/IApp.java
@@ -1,10 +1,12 @@
 package io.jenkins.jenkinsfile.runner.bootstrap;
 
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
+
 /**
  * Signature of the main app code.
  *
  * @author Kohsuke Kawaguchi
  */
 public interface IApp {
-    int run(Bootstrap bootstrap) throws Throwable;
+    int run(JenkinsLauncherCommand command) throws Throwable;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/SideClassLoader.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/SideClassLoader.java
@@ -5,7 +5,7 @@ package io.jenkins.jenkinsfile.runner.bootstrap;
  *
  * @author Kohsuke Kawaguchi
  */
-class SideClassLoader extends ClassLoader {
+public class SideClassLoader extends ClassLoader {
     public SideClassLoader(ClassLoader parent) {
         super(parent);
     }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Util.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Util.java
@@ -25,8 +25,12 @@ public class Util {
     public static class VersionProviderImpl implements CommandLine.IVersionProvider {
         @Override
         public String[] getVersion() throws Exception {
-            return new String[] { readJenkinsPomProperty("jfr.version") };
+            return new String[] { getJenkinsfileRunnerVersion() };
         }
+    }
+
+    public static String getJenkinsfileRunnerVersion() throws IOException {
+        return readJenkinsPomProperty("jfr.version");
     }
 
     public static String getMininumJenkinsVersion() throws IOException {

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Util.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Util.java
@@ -1,5 +1,9 @@
 package io.jenkins.jenkinsfile.runner.bootstrap;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.util.VersionNumber;
+import picocli.CommandLine;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -8,11 +12,42 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Enumeration;
+import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 
 public class Util {
+
+    @CheckForNull
+    private static Properties JFR_PROPERTIES = null;
+
+    public static class VersionProviderImpl implements CommandLine.IVersionProvider {
+        @Override
+        public String[] getVersion() throws Exception {
+            return new String[] { readJenkinsPomProperty("jfr.version") };
+        }
+    }
+
+    public static String getMininumJenkinsVersion() throws IOException {
+        return readJenkinsPomProperty("minimum.jenkins.version");
+    }
+
+    public static boolean isJenkinsVersionSupported(String version) throws IOException {
+        return new VersionNumber(version).isNewerThanOrEqualTo(new VersionNumber(getMininumJenkinsVersion()));
+    }
+
+    public static String readJenkinsPomProperty(String key) throws IOException {
+        if (JFR_PROPERTIES != null) {
+            return JFR_PROPERTIES.getProperty(key);
+        }
+        try (InputStream pomProperties = Bootstrap.class.getResourceAsStream("/jfr.properties")) {
+            Properties props = new Properties();
+            props.load(pomProperties);
+            JFR_PROPERTIES = props;
+            return props.getProperty(key);
+        }
+    }
 
     public static File explodeWar(String jarPath) throws IOException {
         try (JarFile jarfile = new JarFile(new File(jarPath))) {

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
@@ -1,0 +1,240 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jenkins.jenkinsfile.runner.bootstrap.ClassLoaderBuilder;
+import io.jenkins.jenkinsfile.runner.bootstrap.IApp;
+import io.jenkins.jenkinsfile.runner.bootstrap.SideClassLoader;
+import io.jenkins.jenkinsfile.runner.bootstrap.Util;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import picocli.CommandLine;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Command that requires launching a Jenkins instance,
+ * including all required steps like Jenkins WAR and plugins resolution.
+ */
+public abstract class JenkinsLauncherCommand implements Callable<Integer> {
+
+    public static final long CACHE_EXPIRE = System.currentTimeMillis() - 24 * 3600 * 1000;
+
+    @CommandLine.Mixin
+    public JenkinsLauncherOptions launcherOptions;
+
+    public JenkinsLauncherOptions getLauncherOptions() {
+        return launcherOptions;
+    }
+
+    /**
+     * Gets classname of the App which should be launched
+     */
+    @NonNull
+    public abstract String getAppClassName();
+
+    @Override
+    @SuppressFBWarnings("DM_EXIT")
+    public Integer call() throws IllegalStateException {
+        try {
+            // TODO: Remove it: Compatibility mode for Docker images
+            if (System.getenv("FORCE_JENKINS_CLI") != null) {
+                System.out.println("WARNING: Using the CLI compatibility mode. Use the 'cli' subcommand instead of passing the environment variable");
+                RunCLICommand command = new RunCLICommand();
+                command.launcherOptions = this.getLauncherOptions();
+                command.postConstruct();
+                return command.runJenkinsfileRunnerApp();
+            }
+            postConstruct();
+            return runJenkinsfileRunnerApp();
+        } catch (Throwable ex) {
+            throw new RuntimeException("Unhandled exception", ex);
+        }
+    }
+
+    /**
+     * Directory used as cache for downloaded artifacts.
+     */
+    private File cache = new File(System.getProperty("user.home") + "/.jenkinsfile-runner/");
+
+    @PostConstruct
+    public void postConstruct() throws IOException {
+        final JenkinsLauncherOptions settings = getLauncherOptions();
+
+        // Process the Jenkins version
+        if (settings.version != null && settings.warDir != null) {
+            System.err.printf("Error: --jenkins-war and --jenkins-version are mutually exclusive options");
+            System.exit(-1);
+        }
+        if (settings.version != null && !Util.isJenkinsVersionSupported(settings.version)) {
+            System.err.printf("Jenkins version [%s] not supported by this jenkinsfile-runner version (requires %s). %n",
+                    settings.version,
+                    Util.getMininumJenkinsVersion());
+            System.exit(-1);
+        }
+        if (settings.warDir == null) {
+            // TODO: avoid modifying the option
+            settings.warDir = getJenkinsWar(settings.version);
+        }
+        // Explode war if necessary
+        String warPath = settings.warDir.getAbsolutePath();
+        if(FilenameUtils.getExtension(warPath).equals("war") && new File(warPath).isFile()) {
+            System.out.println("Exploding," + warPath +  "this might take some time.");
+            settings.warDir = Util.explodeWar(warPath);
+        }
+
+        if (settings.pluginsDir == null) {
+            // TODO: avoid modifying the option
+            settings.pluginsDir = new File("plugins.txt");
+        } else if (!settings.pluginsDir.exists()) {
+            System.err.println("invalid plugins file.");
+            System.exit(-1);
+        }
+
+        if (settings.pluginsDir.isFile()) {
+            File plugins_txt = settings.pluginsDir;
+            // This is a plugin list file
+            settings.pluginsDir = Files.createTempDirectory("plugins").toFile();
+            for (String line : FileUtils.readLines(plugins_txt, UTF_8)) {
+                String shortname = line;
+                String version = "latest";
+
+                int i = line.indexOf(':');
+                if (i != -1) {
+                    shortname = line.substring(0,i);
+                    version = line.substring(i+1);
+                }
+
+                installPlugin(settings.pluginsDir, shortname, version);
+            }
+        }
+    }
+
+    private File getJenkinsWar(final @CheckForNull String requiredVersion) throws IOException {
+        final String versionToUse;
+        if (requiredVersion == null) {
+            System.out.println("No explicit version has been selected, using latest LTS");
+
+            File latestCore = new File(cache, "war/latest.txt");
+            latestCore.getParentFile().mkdirs();
+            // Check once a day
+            if (!latestCore.exists() || latestCore.lastModified() < CACHE_EXPIRE) {
+                FileUtils.copyURLToFile(URI.create("http://updates.jenkins.io/stable/latestCore.txt").toURL(), latestCore);
+            }
+            versionToUse = FileUtils.readFileToString(latestCore, StandardCharsets.US_ASCII);
+        } else {
+            versionToUse = requiredVersion;
+        }
+
+        System.out.printf("Running pipeline on jenkins %s%n", versionToUse);
+
+        File war = new File(cache, String.format("war/%s/jenkins-war-%s.war", versionToUse, versionToUse));
+        if (!war.exists()) {
+            war.getParentFile().mkdirs();
+            final URL url = new URL(getLauncherOptions().getMirrorURL(String.format("http://updates.jenkins.io/download/war/%s/jenkins.war", versionToUse)));
+            System.out.printf("Downloading jenkins %s...%n", versionToUse);
+            FileUtils.copyURLToFile(url, war);
+        }
+
+        return war;
+    }
+
+    private void installPlugin(File pluginsDir, String shortname, String version) throws IOException {
+        final File install = new File(pluginsDir, shortname + ".jpi");
+        File plugin = new File(cache, String.format("plugins/%s/%s-%s.hpi", shortname, shortname, version));
+        if (!plugin.exists() || ("latest".equals(version) && plugin.lastModified() < CACHE_EXPIRE) ) {
+            plugin.getParentFile().mkdirs();
+            final URL url = new URL(getLauncherOptions().getMirrorURL(String.format("https://updates.jenkins.io/download/plugins/%s/%s/%s.hpi", shortname, version, shortname)));
+            System.out.printf("Downloading jenkins plugin %s (%s)...%n", shortname, version);
+            FileUtils.copyURLToFile(url, plugin);
+        }
+
+        Files.createSymbolicLink(install.toPath(), plugin.toPath());
+    }
+
+    public ClassLoader createJenkinsWarClassLoader() throws PrivilegedActionException {
+        return AccessController.doPrivileged((PrivilegedExceptionAction<ClassLoader>) () -> new ClassLoaderBuilder(new SideClassLoader(getPlatformClassloader()))
+                .collectJars(new File(getLauncherOptions().warDir, "WEB-INF/lib"))
+                // servlet API needs to be visible to jenkins.war
+                .collectJars(new File(getAppRepo(), "javax/servlet"))
+                .make());
+    }
+
+    public ClassLoader createSetupClassLoader(ClassLoader jenkins) throws IOException {
+        return new ClassLoaderBuilder(jenkins)
+                .collectJars(getAppRepo())
+                .make();
+    }
+
+    public int runJenkinsfileRunnerApp() throws Throwable {
+        String appClassName = getAppClassName();
+        if (hasClass(appClassName)) {
+            Class<?> c = Class.forName(appClassName);
+            return  ((IApp) c.newInstance()).run(this);
+        }
+
+        ClassLoader jenkins = createJenkinsWarClassLoader();
+        ClassLoader setup = createSetupClassLoader(jenkins);
+
+        Thread.currentThread().setContextClassLoader(setup);    // or should this be 'jenkins'?
+
+        try {
+            Class<?> c = setup.loadClass(appClassName);
+            return ((IApp) c.newInstance()).run(this);
+        } catch (ClassNotFoundException e) {
+            if (setup instanceof URLClassLoader) {
+                throw new ClassNotFoundException(e.getMessage() + " not found in " + getAppRepo() + ","
+                        + new File(getLauncherOptions().warDir, "WEB-INF/lib") + " " + Arrays.toString(((URLClassLoader) setup).getURLs()),
+                        e);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * In JDK 11, platform classes are not accessible by default but through the platform classloader.
+     */
+    private ClassLoader getPlatformClassloader() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if (isPostJava8()) {
+            return (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
+        }
+
+        return null;
+    }
+
+    private static boolean isPostJava8() {
+        String javaVersion = System.getProperty("java.version");
+        return !javaVersion.startsWith("1.");
+    }
+
+    public boolean hasClass(String className) {
+        try  {
+            Class.forName(className);
+            return true;
+        }  catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    // TODO: move elsewhere
+    public File getAppRepo() {
+        return new File(System.getProperty("app.repo"));
+    }
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
@@ -53,14 +53,6 @@ public abstract class JenkinsLauncherCommand implements Callable<Integer> {
     @SuppressFBWarnings("DM_EXIT")
     public Integer call() throws IllegalStateException {
         try {
-            // TODO: Remove it: Compatibility mode for Docker images
-            if (System.getenv("FORCE_JENKINS_CLI") != null) {
-                System.out.println("WARNING: Using the CLI compatibility mode. Use the 'cli' subcommand instead of passing the environment variable");
-                RunCLICommand command = new RunCLICommand();
-                command.launcherOptions = this.getLauncherOptions();
-                command.postConstruct();
-                return command.runJenkinsfileRunnerApp();
-            }
             postConstruct();
             return runJenkinsfileRunnerApp();
         } catch (Throwable ex) {

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
@@ -34,7 +34,7 @@ public class JenkinsLauncherOptions {
     public String version;
 
     @CommandLine.Option(names = { "-m", "--mirror"},
-            description = "mirror site of Jenkins, defaults to http://updates.jenkins.io/download. Get the mirror list from http://mirrors.jenkins-ci.org/status.html")
+            description = "Download mirror site of Jenkins, defaults to http://updates.jenkins.io/download. Get the mirror list from http://mirrors.jenkins-ci.org/status.html")
     public String mirror;
 
     /**

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
@@ -1,0 +1,61 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import picocli.CommandLine;
+
+import java.io.File;
+
+/**
+ * Arguments needed to launch a Jenkins instance.
+ * @see JenkinsLauncherCommand
+ */
+public class JenkinsLauncherOptions {
+
+    /**
+     * Exploded jenkins.war
+     */
+    @CommandLine.Option(names = { "-w", "--jenkins-war" },
+            description = "Path to exploded jenkins war directory." +
+                    "Depending on packaging, it may contain the entire WAR " +
+                    "or just resources to be loaded by the WAR file, for example Groovy hooks or extra libraries.")
+    @CheckForNull
+    public File warDir;
+
+    /**
+     * Where to load plugins from?
+     */
+    @CommandLine.Option(names = { "-p", "--plugins" },
+            description = "Plugins required to run pipeline. Either a plugins.txt file or a /plugins installation directory. Defaults to plugins.txt")
+    public File pluginsDir;
+
+    @CommandLine.Option(names = { "-jv", "--jenkins-version"},
+            description = "Jenkins version to use if Jenkins WAR is not specified by --jenkins-war. Defaults to the latest LTS")
+    @CheckForNull
+    public String version;
+
+    @CommandLine.Option(names = { "-m", "--mirror"},
+            description = "mirror site of Jenkins, defaults to http://updates.jenkins.io/download. Get the mirror list from http://mirrors.jenkins-ci.org/status.html")
+    public String mirror;
+
+    /**
+     * Jenkins Home for the Run.
+     */
+    @CheckForNull
+    @CommandLine.Option(names = "--runHome",
+            description = "Path to the empty Jenkins Home directory to use for this run. If not specified a temporary directory will be created. " +
+                    "Note that the folder specified via --runHome will not be disposed after the run")
+    public File runHome;
+
+    @CheckForNull
+    @CommandLine.Option(names = "--withInitHooks",
+            description = "Path to a directory containing Groovy Init Hooks to copy into init.groovy.d")
+    public File withInitHooks;
+
+    public String getMirrorURL(String url) {
+        if (this.mirror == null || "".equals(this.mirror.trim())) {
+            return url;
+        }
+
+        return url.replace("https://updates.jenkins.io/download", this.mirror);
+    }
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
@@ -41,10 +41,10 @@ public class JenkinsLauncherOptions {
      * Jenkins Home for the Run.
      */
     @CheckForNull
-    @CommandLine.Option(names = "--runHome",
+    @CommandLine.Option(names = {"--jenkinsHome", "--runHome"},
             description = "Path to the empty Jenkins Home directory to use for this run. If not specified a temporary directory will be created. " +
-                    "Note that the folder specified via --runHome will not be disposed after the run")
-    public File runHome;
+                    "Note that the specified folder will not be disposed after the run")
+    public File jenkinsHome;
 
     @CheckForNull
     @CommandLine.Option(names = "--withInitHooks",

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -1,0 +1,73 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.util.Map;
+
+// TODO: Split Pipeline and generic options?
+/**
+ * Contains options required for a Jenkins build run.
+ */
+public class PipelineRunOptions {
+
+    /**package**/ static final String DEFAULT_JOBNAME = "job";
+
+    /**
+     * Checked out copy of the working space.
+     */
+    @CommandLine.Option(names = { "-f", "--file" },
+            description = "Path to Jenkinsfile or directory containing a Jenkinsfile, defaults to ./Jenkinsfile")
+    public File jenkinsfile;
+
+    /**
+     * Workspace for the Run
+     */
+    @CheckForNull
+    @CommandLine.Option(names = "--runWorkspace",
+            description = "Path to the workspace of the run to be used within the node{} context. " +
+                    "It applies to both Jenkins master and agents (or side containers) if any. " +
+                    "Requires Jenkins 2.119 or above")
+    public File runWorkspace;
+
+
+
+    /**
+     * Job name for the Run.
+     */
+    @CommandLine.Option(names = { "-n", "--job-name"},
+            description = "Name of the job the run belongs to")
+    public String jobName = DEFAULT_JOBNAME;
+
+    /**
+     * Cause of the Run.
+     */
+    @CommandLine.Option(names = { "-c", "--cause"},
+            description = "Cause of the run")
+    public String cause;
+
+    /**
+     * BuildNumber of the Run.
+     */
+    @CommandLine.Option(names = { "-b", "--build-number"},
+            description = "Build number of the run")
+    public int buildNumber = 1;
+
+    @CommandLine.Option(names = { "-a", "--arg" },
+            description = "Parameters to be passed to the build. Use multiple -a switches for multiple params")
+    @CheckForNull
+    public Map<String,String> workflowParameters;
+
+    @CommandLine.Option(names = { "-ns", "--no-sandbox" },
+            description = "Disable workflow job execution within sandbox environment")
+    public boolean noSandBox;
+
+    @CommandLine.Option(names = { "-u", "--keep-undefined-parameters" },
+            description = "Keep undefined parameters if set")
+    public boolean keepUndefinedParameters = false;
+
+    @CommandLine.Option(names = "--scm",
+            description = "YAML definition of the SCM, with optional credentials, to use for the project")
+    public File scm;
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunCLICommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunCLICommand.java
@@ -1,0 +1,13 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "cli", description = "Runs interactive Jenkins CLI")
+public class RunCLICommand extends JenkinsLauncherCommand {
+
+    @Override
+    public String getAppClassName() {
+        return "io.jenkins.jenkinsfile.runner.CLIApp";
+    }
+
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunCLICommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunCLICommand.java
@@ -2,7 +2,7 @@ package io.jenkins.jenkinsfile.runner.bootstrap.commands;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "cli", description = "Runs interactive Jenkins CLI")
+@CommandLine.Command(name = "cli", description = "Runs interactive Jenkins CLI", mixinStandardHelpOptions = true)
 public class RunCLICommand extends JenkinsLauncherCommand {
 
     @Override

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunJenkinsfileCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunJenkinsfileCommand.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * @author Oleg Nenashev
  * @since TODO
  */
-@CommandLine.Command(name="run", description = "Runs Jenkinsfile")
+@CommandLine.Command(name="run", description = "Runs Jenkinsfile", mixinStandardHelpOptions = true)
 public class RunJenkinsfileCommand extends JenkinsLauncherCommand {
 
     @CommandLine.Mixin

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunJenkinsfileCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunJenkinsfileCommand.java
@@ -1,0 +1,80 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@CommandLine.Command(name="run", description = "Runs Jenkinsfile")
+public class RunJenkinsfileCommand extends JenkinsLauncherCommand {
+
+    @CommandLine.Mixin
+    public PipelineRunOptions pipelineRunOptions;
+
+    private static final String WORKSPACES_DIR_SYSTEM_PROPERTY = "jenkins.model.Jenkins.workspacesDir";
+
+    @Override
+    public String getAppClassName() {
+        return "io.jenkins.jenkinsfile.runner.App";
+    }
+
+    public PipelineRunOptions getPipelineRunOptions() {
+        return pipelineRunOptions;
+    }
+
+    @Override
+    public void postConstruct() throws IOException {
+        if (pipelineRunOptions.jenkinsfile == null) {
+            pipelineRunOptions.jenkinsfile = new File("Jenkinsfile");
+        }
+        if (!pipelineRunOptions.jenkinsfile.exists()) {
+            System.err.println("no Jenkinsfile in current directory.");
+            System.exit(-1);
+        }
+        if (pipelineRunOptions.jenkinsfile.isDirectory()) {
+            pipelineRunOptions.jenkinsfile = new File(pipelineRunOptions.jenkinsfile, "Jenkinsfile");
+        }
+
+        if (pipelineRunOptions.runWorkspace != null){
+            if (System.getProperty(WORKSPACES_DIR_SYSTEM_PROPERTY) != null) {
+                //TODO(oleg_nenashev): It would have been better to keep it other way, but made it as is to retain compatibility
+                System.out.println("Ignoring the --runWorkspace argument, because an explicit System property is set (-D" + WORKSPACES_DIR_SYSTEM_PROPERTY + ")");
+            } else {
+                System.setProperty(WORKSPACES_DIR_SYSTEM_PROPERTY, pipelineRunOptions.runWorkspace.getAbsolutePath());
+            }
+        }
+
+        if (pipelineRunOptions.workflowParameters == null){
+            pipelineRunOptions.workflowParameters = new HashMap<>();
+        }
+        for (Map.Entry<String, String> workflowParameter : pipelineRunOptions.workflowParameters.entrySet()) {
+            if (workflowParameter.getValue() == null) {
+                workflowParameter.setValue("");
+            }
+        }
+
+        if (pipelineRunOptions.cause != null) {
+            pipelineRunOptions.cause = pipelineRunOptions.cause.trim();
+            if (pipelineRunOptions.cause.isEmpty())  {
+                pipelineRunOptions.cause = null;
+            }
+        }
+
+        if (pipelineRunOptions.jobName.isEmpty()) {
+            pipelineRunOptions.jobName = PipelineRunOptions.DEFAULT_JOBNAME;
+        }
+
+        if (pipelineRunOptions.keepUndefinedParameters) {
+            System.setProperty("hudson.model.ParametersAction.keepUndefinedParameters", "true");
+        }
+
+        super.postConstruct();
+    }
+
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/VersionCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/VersionCommand.java
@@ -1,0 +1,17 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import io.jenkins.jenkinsfile.runner.bootstrap.Util;
+import picocli.CommandLine.Command;
+
+import java.util.concurrent.Callable;
+
+// TODO: Add support for printing Jenkins core and Pipeline versions? Will need to booth the Jenkins instance
+@Command(name = "version", description = "Shows Jenkinsfile Runner version")
+public class VersionCommand implements Callable<Integer> {
+
+    @Override
+    public Integer call() throws Exception {
+        System.out.println(Util.getJenkinsfileRunnerVersion());
+        return 0;
+    }
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/VersionCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/VersionCommand.java
@@ -6,7 +6,7 @@ import picocli.CommandLine.Command;
 import java.util.concurrent.Callable;
 
 // TODO: Add support for printing Jenkins core and Pipeline versions? Will need to booth the Jenkins instance
-@Command(name = "version", description = "Shows Jenkinsfile Runner version")
+@Command(name = "version", description = "Shows Jenkinsfile Runner version", mixinStandardHelpOptions = true)
 public class VersionCommand implements Callable<Integer> {
 
     @Override

--- a/bootstrap/src/test/java/io/jenkins/jenkinsfile/runner/bootstrap/BootstrapTest.java
+++ b/bootstrap/src/test/java/io/jenkins/jenkinsfile/runner/bootstrap/BootstrapTest.java
@@ -13,6 +13,11 @@ public class BootstrapTest {
     }
 
     @Test
+    public void printsSubcommandHelp() {
+        assertCommandSuccess("help", "cli");
+    }
+
+    @Test
     public void printsVersion() {
         assertCommandSuccess("--version");
         assertCommandSuccess("-V");
@@ -21,7 +26,7 @@ public class BootstrapTest {
     @Test
     public void supportsMultipleArguments() {
         Bootstrap bootstrap = assertCommandSuccess("--arg=ARG1=value1", "--arg=ARG2=value2", "--version");
-        assertEquals("Wrong number of parameters was parsed", bootstrap.workflowParameters.size(), 2);
+        assertEquals("Wrong number of parameters was parsed", bootstrap.pipelineRunOptions.workflowParameters.size(), 2);
     }
 
     private Bootstrap assertCommandSuccess(String ... args) throws AssertionError {

--- a/bootstrap/src/test/java/io/jenkins/jenkinsfile/runner/bootstrap/BootstrapTest.java
+++ b/bootstrap/src/test/java/io/jenkins/jenkinsfile/runner/bootstrap/BootstrapTest.java
@@ -15,6 +15,7 @@ public class BootstrapTest {
     @Test
     public void printsSubcommandHelp() {
         assertCommandSuccess("help", "cli");
+        assertCommandSuccess("cli", "--help");
     }
 
     @Test

--- a/bootstrap/src/test/java/io/jenkins/jenkinsfile/runner/bootstrap/BootstrapTest.java
+++ b/bootstrap/src/test/java/io/jenkins/jenkinsfile/runner/bootstrap/BootstrapTest.java
@@ -19,6 +19,7 @@ public class BootstrapTest {
 
     @Test
     public void printsVersion() {
+        assertCommandSuccess("version");
         assertCommandSuccess("--version");
         assertCommandSuccess("-V");
     }

--- a/docs/developer/STRUCTURE.adoc
+++ b/docs/developer/STRUCTURE.adoc
@@ -31,8 +31,10 @@ Contains special classloader configuration so that Jenkinsfile Runner is able to
 own project classes. It also contains the `Bootstrap` class:
 
 * The `main()` for the Jenkinsfile Runner application.
+* Contains Jenkinsfile Runner Command options and implementations.
 * Configures the execution based on the values of the provided parameters.
-* Launches the execution.
+* Launches the execution and prepares the environment.
+  In particular, the module prepares the Jenkins WAR and plugins when it is needed.
 
 == `payload` module
 

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/CLIApp.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/CLIApp.java
@@ -2,22 +2,22 @@ package io.jenkins.jenkinsfile.runner;
 
 import io.jenkins.jenkinsfile.runner.bootstrap.IApp;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunCLICommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
 
 /**
- * App handler for {@link RunJenkinsfileCommand}.
+ * App handler for {@link RunCLICommand}.
  * This code runs after Jetty and Jenkins classloaders are set up correctly.
  */
-public class App implements IApp {
-
+public class CLIApp implements IApp {
     @Override
     public int run(JenkinsLauncherCommand command) throws Throwable {
-        if (!(command instanceof RunJenkinsfileCommand)) {
+        if (!(command instanceof RunCLICommand)) {
             throw new IllegalStateException(
                     String.format("%s is invoked with a wrong class type. Required=%s, got=%s",
-                            App.class, RunJenkinsfileCommand.class, command.getClass()));
+                            CLIApp.class, RunCLICommand.class, command.getClass()));
         }
-        JenkinsfileRunnerLauncher launcher = new JenkinsfileRunnerLauncher((RunJenkinsfileCommand) command);
+        CLILauncher launcher = new CLILauncher((RunCLICommand) command);
         return launcher.launch();
     }
 }

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/CLILauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/CLILauncher.java
@@ -2,7 +2,7 @@ package io.jenkins.jenkinsfile.runner;
 
 import hudson.cli.CLICommand;
 import hudson.security.ACL;
-import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunCLICommand;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -15,9 +15,9 @@ import java.util.Locale;
 /**
  * Sets up a Jenkins environment that provides an interactive CLI.
  */
-public class CLILauncher extends JenkinsLauncher {
-    public CLILauncher(Bootstrap bootstrap) {
-        super(bootstrap);
+public class CLILauncher extends JenkinsLauncher<RunCLICommand> {
+    public CLILauncher(RunCLICommand command) {
+        super(command);
     }
 
     @Override

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -34,17 +34,17 @@ public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends 
     public JenkinsLauncher(T command) {
         this.command = command;
         final JenkinsLauncherOptions launcherOptions = command.getLauncherOptions();
-        if (launcherOptions.runHome != null) {
-            String[] list = launcherOptions.runHome.list();
-            if (!launcherOptions.runHome.isDirectory() || list == null) {
-                throw new IllegalArgumentException("--runHome is not a directory: " + launcherOptions.runHome.getAbsolutePath());
+        if (launcherOptions.jenkinsHome != null) {
+            String[] list = launcherOptions.jenkinsHome.list();
+            if (!launcherOptions.jenkinsHome.isDirectory() || list == null) {
+                throw new IllegalArgumentException("--runHome is not a directory: " + launcherOptions.jenkinsHome.getAbsolutePath());
             }
             if (list.length > 0) {
-                throw new IllegalArgumentException("--runHome directory is not empty: " + launcherOptions.runHome.getAbsolutePath());
+                throw new IllegalArgumentException("--runHome directory is not empty: " + launcherOptions.jenkinsHome.getAbsolutePath());
             }
 
             //Override homeLoader to use existing directory instead of creating temporary one
-            this.homeLoader = new JenkinsHomeLoader.UseExisting(launcherOptions.runHome.getAbsoluteFile());
+            this.homeLoader = new JenkinsHomeLoader.UseExisting(launcherOptions.jenkinsHome.getAbsoluteFile());
         }
     }
 

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -2,7 +2,8 @@ package io.jenkins.jenkinsfile.runner;
 
 import hudson.ClassicPluginStrategy;
 import hudson.util.PluginServletFilter;
-import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
 import io.jenkins.jenkinsfile.runner.util.JenkinsHomeLoader;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.security.AbstractLoginService;
@@ -24,24 +25,26 @@ import java.util.logging.Logger;
 /**
  * Shared behaviour for different modes of launching an embedded Jenkins in the context of jenkinsfile-runner.
  */
-public abstract class JenkinsLauncher extends JenkinsEmbedder {
-    protected final Bootstrap bootstrap;
+public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends JenkinsEmbedder {
+
+    protected final T command;
 
     private static final Logger LOGGER = Logger.getLogger(JenkinsLauncher.class.getName());
 
-    public JenkinsLauncher(Bootstrap bootstrap) {
-        this.bootstrap = bootstrap;
-        if (bootstrap.runHome != null) {
-            String[] list = bootstrap.runHome.list();
-            if (!bootstrap.runHome.isDirectory() || list == null) {
-                throw new IllegalArgumentException("--runHome is not a directory: " + bootstrap.runHome.getAbsolutePath());
+    public JenkinsLauncher(T command) {
+        this.command = command;
+        final JenkinsLauncherOptions launcherOptions = command.getLauncherOptions();
+        if (launcherOptions.runHome != null) {
+            String[] list = launcherOptions.runHome.list();
+            if (!launcherOptions.runHome.isDirectory() || list == null) {
+                throw new IllegalArgumentException("--runHome is not a directory: " + launcherOptions.runHome.getAbsolutePath());
             }
             if (list.length > 0) {
-                throw new IllegalArgumentException("--runHome directory is not empty: " + bootstrap.runHome.getAbsolutePath());
+                throw new IllegalArgumentException("--runHome directory is not empty: " + launcherOptions.runHome.getAbsolutePath());
             }
 
             //Override homeLoader to use existing directory instead of creating temporary one
-            this.homeLoader = new JenkinsHomeLoader.UseExisting(bootstrap.runHome.getAbsoluteFile());
+            this.homeLoader = new JenkinsHomeLoader.UseExisting(launcherOptions.runHome.getAbsoluteFile());
         }
     }
 
@@ -50,16 +53,18 @@ public abstract class JenkinsLauncher extends JenkinsEmbedder {
      */
     @Override
     protected ServletContext createWebServer() throws Exception {
+        final JenkinsLauncherOptions launcherOptions = command.getLauncherOptions();
+
         QueuedThreadPool queuedThreadPool = new QueuedThreadPool(10);
         server = new Server(queuedThreadPool);
 
-        WebAppContext context = new WebAppContext(bootstrap.warDir.getPath(), contextPath);
+        WebAppContext context = new WebAppContext(launcherOptions.warDir.getPath(), contextPath);
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
         context.addBean(new NoListenerConfiguration(context));
         server.setHandler(context);
         context.getSecurityHandler().setLoginService(configureUserRealm());
-        context.setResourceBase(bootstrap.warDir.getPath());
+        context.setResourceBase(launcherOptions.warDir.getPath());
 
         // Jenkins core and some extension points supply extension points which try to access the filter
         // In Jenkins core it is define in web.xml
@@ -70,7 +75,7 @@ public abstract class JenkinsLauncher extends JenkinsEmbedder {
 
         localPort = -1;
 
-        setPluginManager(new PluginManagerImpl(context.getServletContext(), bootstrap.pluginsDir));
+        setPluginManager(new PluginManagerImpl(context.getServletContext(), launcherOptions.pluginsDir));
 
         return context.getServletContext();
     }
@@ -146,15 +151,16 @@ public abstract class JenkinsLauncher extends JenkinsEmbedder {
 
     @Override
     protected void setupHome(File home) throws IOException {
-        if (bootstrap.withInitHooks != null) {
-            String[] list = bootstrap.withInitHooks.list();
-            if (!bootstrap.withInitHooks.isDirectory() || list == null) {
-                throw new IllegalArgumentException("--withInitHooks is not a directory: " + bootstrap.withInitHooks.getAbsolutePath());
+        final JenkinsLauncherOptions launcherOptions = command.getLauncherOptions();
+        if (launcherOptions.withInitHooks != null) {
+            String[] list = launcherOptions.withInitHooks.list();
+            if (!launcherOptions.withInitHooks.isDirectory() || list == null) {
+                throw new IllegalArgumentException("--withInitHooks is not a directory: " + launcherOptions.withInitHooks.getAbsolutePath());
             }
             if (list.length == 0) {
-                throw new IllegalArgumentException("--withInitHooks directory does not contain any hook: " + bootstrap.withInitHooks.getAbsolutePath());
+                throw new IllegalArgumentException("--withInitHooks directory does not contain any hook: " + launcherOptions.withInitHooks.getAbsolutePath());
             }
-            FileUtils.copyDirectory(bootstrap.withInitHooks, home.getAbsoluteFile().toPath().resolve("init.groovy.d").toFile());
+            FileUtils.copyDirectory(launcherOptions.withInitHooks, home.getAbsoluteFile().toPath().resolve("init.groovy.d").toFile());
         }
     }
 

--- a/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/JFRTestUtil.java
+++ b/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/JFRTestUtil.java
@@ -1,8 +1,10 @@
 package io.jenkins.jenkinsfile.runner.vanilla;
 
 import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
-import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.args4j.CmdLineParser;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
@@ -24,25 +26,27 @@ import static org.junit.Assert.assertTrue;
 public class JFRTestUtil {
 
     /**
-     * Runs JFR using the low-level methods, {@link Bootstrap#postConstruct(CmdLineParser)} is skipped.
+     * Runs JFR using the low-level methods, {@link JenkinsLauncherCommand#postConstruct()} is skipped.
      */
     @CheckReturnValue
     public static int run(File jenkinsfile) throws Throwable {
-        Bootstrap jfr = new Bootstrap();
+        RunJenkinsfileCommand jfr = new RunJenkinsfileCommand();
         File vanillaTarget = new File("target");
-        jfr.warDir = new File(vanillaTarget, "war");
-        jfr.pluginsDir = new File(vanillaTarget, "plugins");
-        jfr.jenkinsfile = jenkinsfile;
+        jfr.launcherOptions = new JenkinsLauncherOptions();
+        jfr.pipelineRunOptions = new PipelineRunOptions();
+        jfr.launcherOptions.warDir = new File(vanillaTarget, "war");
+        jfr.launcherOptions.pluginsDir = new File(vanillaTarget, "plugins");
+        jfr.pipelineRunOptions.jenkinsfile = jenkinsfile;
 
         //TODO: PostConstruct is not invoked
-        return jfr.runJenkinsfile();
+        return jfr.runJenkinsfileRunnerApp();
     }
 
     /**
      * Runs JFR using the CLI routines
      */
     @CheckReturnValue
-    public static int runAsCLI(File jenkinsfile) throws Throwable, CmdLineException {
+    public static int runAsCLI(File jenkinsfile) throws Throwable {
         return runAsCLI(jenkinsfile, null);
     }
 
@@ -51,7 +55,7 @@ public class JFRTestUtil {
      * Runs JFR using the CLI routines
      */
     @CheckReturnValue
-    public static int runAsCLI(File jenkinsfile, @CheckForNull Collection<String> additionalArgs) throws Throwable, CmdLineException {
+    public static int runAsCLI(File jenkinsfile, @CheckForNull Collection<String> additionalArgs) throws Throwable {
         File vanillaTarget = new File("target");
         File warDir = new File(vanillaTarget, "war");
         File pluginsDir = new File(vanillaTarget, "plugins");


### PR DESCRIPTION
First step for https://github.com/jenkinsci/jenkinsfile-runner/issues/429 . The change splits the "cli" and "run" commands while retaining compatibility with the documented CLI

- [x] - Refactor the code to support multiple subcommand
- [x] - Deprecate the `--cli` option
- [x] - Introduce `run` and `cli` commands for existing functionality + `generate-completion` for autocompletion
- [x] - Update the CLI documentation in README. Preview: https://github.com/jenkinsci/jenkinsfile-runner/blob/190f57f05c682041fb96c6122252480cb72363fa/README.adoc#command-line-interface-cli

Command examples:

```
java -jar jfr.jar run -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/ -f .
```

```
java -jar jfr.jar cli -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/ 
```

CC @literalplus 
