### PR TITLE
Ensure that the shutdown logic is invoked by default + Remove commons-logging JAR and use slf4j + Add jcl and log4j bridges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -178,6 +178,12 @@ Advanced arguments:
 ** NOTE: This option will be reworked in the future once the Plugin Installation Manager tool is integrated
 * `--withInitHooks FILE` - Path to the https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/[Groovy init hooks] directory
     Hooks can be also passed via `WEB-INF/groovy.init.d/**` directory within the Jenkins WAR resource loader defined in `--jenkins-war`.
+* `--skipShutdown` - Skips the Jenkins shutdown logic to improve performance.
+  Jenkinsfile Runner will abort the instance instead of gracefully releasing the resources.
+  For example, agent connections will not be terminated.
+  Also, plugin https://javadoc.jenkins.io/hudson/init/Terminator.html[@Terminator] extensions will not be invoked.
+  It may lead to undefined behavior in the system, including potential data loss.
+  This option is considered safe for the Vanilla package with the default plugin set.
 
 ==== Running Jenkinsfiles (`run` command)
 

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
@@ -51,6 +51,14 @@ public class JenkinsLauncherOptions {
             description = "Path to a directory containing Groovy Init Hooks to copy into init.groovy.d")
     public File withInitHooks;
 
+    @CheckForNull
+    @CommandLine.Option(names = "--skipShutdown",
+            description = "Forces Jenkinsfile Runner to skip the shutdown logic. " +
+                    "It reduces the instance termination time but may lead to unexpected behavior in plugins " +
+                    "which release external resources on clean up synchronous task queues on shutdown.")
+    public boolean skipShutdown;
+
+
     public String getMirrorURL(String url) {
         if (this.mirror == null || "".equals(this.mirror.trim())) {
             return url;

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -88,10 +88,6 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
     </dependency>
@@ -100,8 +96,21 @@
       <artifactId>support-log-formatter</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <scope>provided</scope> <!-- by jcl-over-slf4j -->
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -137,15 +137,14 @@ public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends 
         }
     }
 
-    /**
-     * Skips the clean up.
-     *
-     * This was initially motivated by SLF4J leaving gnarly messages.
-     * The whole JVM is going to die anyway, so we don't really care about cleaning up anything nicely.
-     */
     @Override
     public void after() throws Exception {
-        jenkins = null;
+        if (command.launcherOptions.skipShutdown) {
+            // Skips the clean up. This was initially motivated by SLF4J leaving gnarly messages.
+            // The whole JVM is going to die anyway, but without the cleanup the Jenkins termination logic won't be invoked
+            // It may lead to issues in plugins which rely on the shutdown logic (agent connectors, async event streaming, etc.)
+            jenkins = null;
+        }
         super.after();
     }
 


### PR DESCRIPTION
This change reverts the previous assumption that we are fine with doing hard resets in JFR. Some logic might require graceful shutdown, e.g. when connecting external agents or using plugin with asynchronous operations. This patch restores the standard Jenkins behavior, but at the same time offers the opt-out CLI option.

- [x] - Change the termination behavior
  * Tested on the SSH Build  Agents plugin, termination is invoked properly
- [x] - Fix shutdown issues
- [x] - Update README

Closes #406 . CC @michaelneale @abayer 