### PR TITLE
Discourage users from running the preview Standalone JAR due to extension loading issues

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,32 +31,29 @@ There are more demos available in the project.
 == Usage in command-line
 
 Jenkinsfile Runner can be run in the command line or in Docker.
-In case you want to run it in the command line just follow these steps:
+To run it in the command line follow these steps:
 
-. Download the jar file available in https://repo.jenkins-ci.org/webapp/#/home[artifactory] or
-build the source code from this repository (see link:./CONTRIBUTING.adoc[contributing guidelines])
+. Download the Jenkinsfile Runner ZIP archive available in https://github.com/jenkinsci/jenkinsfile-runner/releases[GitHub Releases].
+** There is also a standalone JAR option available there, but this is a preview-only feature
+   (see https://github.com/jenkinsci/jenkinsfile-runner/issues/350[issue #350]).
+** Latest unreleased versions can be also built from source code.
+   See the link:./CONTRIBUTING.adoc[contributing guidelines] if you want to build Jenkinsfile Runner on your own.
 . Prepare the execution environment
-. Run the command
+. Run the Pipeline
 
 === Preparation
 
-Find `jenkins.war` that represents the version of Jenkins that you’d like to use,
-then unzip it somewhere.
+Jenkinsfile Runner bundle includes the Jenkins core and a minimum set of plugins.
+More plugins can be installed on-demand.
+If it is not needed, just skip this step.
 
-....
-wget http://mirrors.jenkins.io/war-stable/latest/jenkins.war
-unzip jenkins.war -d /tmp/jenkins
-....
+To add plugins, create a directory and assemble all the plugins that you’d like to use with the build.
+There are two ways to do it:
 
-Next, create a directory and assemble all the plugins that you’d like to use with the build.
-One way to do this is to run the Jenkins setup wizard and install the default set of plugins.
-This is a gap intended to be filled with https://github.com/jenkinsci/configuration-as-code-plugin[configuration as code].
-
-....
-JENKINS_HOME=/tmp/jenkins_home java -jar jenkins.war
-# go to http://localhost:8080/, follow the installation step
-# and install the recommended set of plugins
-....
+* Use the https://github.com/jenkinsci/plugin-installation-manager-tool[Plugin Installation Manager Tool]
+  to install plugins into a new plugin directory.
+* Run the Jenkins setup wizard and install the desired set of plugins.
+  After that, the plugins can be retrieved from `JENKINS_HOME/plugins`.
 
 === Execution
 

--- a/demo/casc/README.md
+++ b/demo/casc/README.md
@@ -22,10 +22,10 @@ An environment variable configured via JCasC: a value configured via JCasC
 
 ## Running the demo locally
 
-Once you build the repository, launch the following command:
+Once you build the repository, launch the following command in bash:
 
 ```bash
-CASC_JENKINS_CONFIG=config/jenkins.yaml java -jar ../../app/target/jenkinsfile-runner-standalone.jar \
+CASC_JENKINS_CONFIG=config/jenkins.yaml ../../app/target/appassembler/bin/jenkinsfile-runner \
   -w ../../vanilla-package/target/war -p ../../vanilla-package/target/plugins/ -f .
 ```
 

--- a/demo/declarative-pipeline/README.md
+++ b/demo/declarative-pipeline/README.md
@@ -15,5 +15,5 @@ docker run --rm -v $(pwd)/Jenkinsfile:/workspace/Jenkinsfile jenkins4eval/jenkin
 Once Jenkinsfile Runner is built locally, the demo can be launched as...
 
 ```bash
-java -jar ../../app/target/jenkinsfile-runner-standalone.jar -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/jenkins.war -f .
+../../app/target/appassembler/bin/jenkinsfile-runner -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/ -f .
 ```

--- a/demo/pipeline-as-yaml/README.md
+++ b/demo/pipeline-as-yaml/README.md
@@ -18,5 +18,5 @@ docker run --rm \
 Once Jenkinsfile Runner is built locally, the demo can be launched as...
 
 ```bash
-java -jar ../../app/target/jenkinsfile-runner-standalone.jar -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/jenkins.war -f ./Jenkinsfile.yml
+../../app/target/appassembler/bin/jenkinsfile-runner -p ../../vanilla-package/target/plugins/ -w ../../vanilla-package/target/war/jenkins.war -f ./Jenkinsfile.yml
 ```

--- a/demo/pipeline-library/README.md
+++ b/demo/pipeline-library/README.md
@@ -9,7 +9,7 @@ Later this demo will be reworked to the native bundling.
 Once Jenkinsfile Runner is built locally, the demo can be launched as...
 
 ```bash
-CASC_JENKINS_CONFIG=$(pwd)/jenkins.yaml java -jar ../../app/target/jenkinsfile-runner-standalone.jar -p ../../vanilla-package/target/plugins/ -f . 
+CASC_JENKINS_CONFIG=$(pwd)/jenkins.yaml ../../app/target/appassembler/bin/jenkinsfile-runner -p ../../vanilla-package/target/plugins/ -f . 
 ```
 
 The demo will likely fail, but you will be able to see that the library is loaded implicitly.


### PR DESCRIPTION
Standalone JAR option is not reliable due to https://github.com/jenkinsci/jenkinsfile-runner/issues/350 . It works on the default Vanilla package, but deviations may lead to the instance exploding. Better to avoid this mode for now.