### PR TITLE
Stop publishing the Uber JAR artifact

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -29,20 +29,8 @@ jobs:
           FILE_NAME=jenkinsfile-runner
           PROJECT_VERSION=${{ steps.set-version.outputs.project-version }}
           echo "::set-output name=file-name::$FILE_NAME"
-          wget -q https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.jar \
-            -O $FILE_NAME-$PROJECT_VERSION.jar
           wget -q https://repo.jenkins-ci.org/releases/$GROUP_ID/$ARTIFACT_ID/$PROJECT_VERSION/$ARTIFACT_ID-$PROJECT_VERSION.zip \
             -O $FILE_NAME-$PROJECT_VERSION.zip
-      - name: Upload artifact uber jar
-        id: upload-artifact-uber-jar
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar
-          asset_name: ${{ steps.fetch-artifact.outputs.file-name }}-${{ steps.set-version.outputs.project-version }}.jar
-          asset_content_type: application/java-archive
       - name: Upload artifact minimum package
         id: upload-artifact-minimum-package
         uses: actions/upload-release-asset@v1.0.2


### PR DESCRIPTION
For now... It does not do anything good with the slim packaging. For the rest of the packaging it does not work either due to extension indexing issues. To be revised