### PR TITLE
Add support for user provided Jenkinsfile path

### DIFF
--- a/packaging/docker/unix/jenkinsfile-runner-launcher
+++ b/packaging/docker/unix/jenkinsfile-runner-launcher
@@ -7,13 +7,16 @@ if [ -n "$JDK_11" ] ; then
   export JAVA_OPTS="--illegal-access=permit $JAVA_OPTS"
 fi
 
-if [ -f "/workspace/Jenkinsfile" ] ; then
-  JENKINSFILE_PATH="/workspace/Jenkinsfile"
-elif [ -f "/workspace/Jenkinsfile.yml" ] ; then
-  JENKINSFILE_PATH="/workspace/Jenkinsfile.yml"
-else
-  # Default fallback which delegates discovery to JFR
-  JENKINSFILE_PATH=/workspace
+# check if the user has provided a path to the file
+if [ -z "${JENKINSFILE_PATH}" ] ; then
+  if [ -f "/workspace/Jenkinsfile" ] ; then
+    JENKINSFILE_PATH="/workspace/Jenkinsfile"
+  elif [ -f "/workspace/Jenkinsfile.yml" ] ; then
+    JENKINSFILE_PATH="/workspace/Jenkinsfile.yml"
+  else
+    # Default fallback which delegates discovery to JFR
+    JENKINSFILE_PATH=/workspace
+  fi
 fi
 
 /app/bin/jenkinsfile-runner \


### PR DESCRIPTION
Hello :slightly_smiling_face: , thank you for making this awesome project!

I just wanted to add a small feature request for the docker container portion of this project.

I didn't necessarily want to directly mount the Jenkinsfile into the exact location `/workspace/Jenkinsfile`, so I was curious if adding a check for the `JENKINSFILE_PATH` variable could be added. That way if a user wants to specify a full path to the Jenkinsfile then they could simply pass it with a: `-e JENKINSFILE_PATH='<path_to_jenkinsfile>'`. This would give the flexibility of mounting a directory and then specifying the full path per that variable, while still maintaining the default nature of executing the already planned happy path a user has now.

Please let me know if there is anything, and thank you again for this amazing project :grin: 