### PR TITLE
Make Pipeline as YAML plugin optional.

### DIFF
--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -76,12 +76,18 @@
       <artifactId>configuration-as-code</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>pipeline-as-yaml</artifactId>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-definition</artifactId>
+      <artifactId>pipeline-model-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
+          <artifactId>jackson-datatype-json-org</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/payload/pom.xml
+++ b/payload/pom.xml
@@ -34,5 +34,17 @@
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>pipeline-as-yaml</artifactId>
+      <version>0.12-rc</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
+          <artifactId>jackson-datatype-json-org</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/PipelineAsYAMLDefinitionProvider.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/PipelineAsYAMLDefinitionProvider.java
@@ -1,0 +1,32 @@
+package io.jenkins.jenkinsfile.runner;
+
+import hudson.Extension;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.multibranch.yaml.pipeline.PipelineAsYamlScriptFlowDefinition;
+
+import java.io.IOException;
+
+@Extension(ordinal = -1000, optional = true)
+public class PipelineAsYAMLDefinitionProvider extends PipelineDefinitionProvider {
+
+    static final String definitionName;
+
+    static {
+        definitionName = PipelineAsYAMLDefinitionProvider.class.getName();
+    }
+
+    public boolean matches(PipelineRunOptions options) {
+        String filepath = options.jenkinsfile.getAbsolutePath();
+        return filepath.endsWith("Jenkinsfile.yml") || filepath.endsWith("Jenkinsfile.yaml");
+    }
+
+    @Override
+    public void instrumentJob(WorkflowJob job, PipelineRunOptions runOptions) throws IOException {
+
+        // We do not support SCM definition here due to https://github.com/jenkinsci/pipeline-as-yaml-plugin/issues/28
+        job.setDefinition(new PipelineAsYamlScriptFlowDefinition(
+                FileUtils.readFileToString(runOptions.jenkinsfile), !runOptions.noSandBox));
+    }
+}

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/PipelineDefinitionProvider.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/PipelineDefinitionProvider.java
@@ -1,0 +1,40 @@
+package io.jenkins.jenkinsfile.runner;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
+
+/**
+ * Allows specifying custom Runner implementations
+ */
+@Restricted(Beta.class)
+public abstract class PipelineDefinitionProvider implements ExtensionPoint {
+
+    /**
+     * Check whether the extension point can provide a Pipeline for the request.
+     * @param options run options
+     * @return {@code true} if the extension can produce the Pipeline definition
+     */
+    public abstract boolean matches(PipelineRunOptions options);
+
+    /**
+     * Configures the Pipeline job.
+     *
+     * Can be overridden if there is no need to update the entire Pipeline.
+     * The extension may pass additional configurations and actions.
+     *
+     * @param job Job to be updated
+     * @throws Exception modification failed
+     */
+    public abstract void instrumentJob(WorkflowJob job, PipelineRunOptions args) throws Exception;
+
+    /**
+     * Get all extension instances.
+     */
+    public static ExtensionList<PipelineDefinitionProvider> all() {
+        return ExtensionList.lookup(PipelineDefinitionProvider.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,6 @@ THE SOFTWARE.
         <artifactId>pipeline-utility-steps</artifactId>
         <version>2.6.1</version>
       </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>pipeline-as-yaml</artifactId>
-        <version>0.12-rc</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../packaging-parent-pom</relativePath>
   </parent>
 
-  <artifactId>vanilla-package</artifactId>
+  <artifactId>smoke-tests</artifactId>
   <description>Defines plugins which should be included into the Vanilla bundle</description>
 
   <properties>
@@ -50,6 +50,11 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>pipeline-as-yaml</artifactId>
+      <version>0.12-rc</version>
     </dependency>
 
     <!-- Upper bounds -->

--- a/vanilla-package/src/test/resources/io/jenkins/jenkinsfile/runner/vanilla/SmokeTest/wrongConfig/jenkins.yaml
+++ b/vanilla-package/src/test/resources/io/jenkins/jenkinsfile/runner/vanilla/SmokeTest/wrongConfig/jenkins.yaml
@@ -1,0 +1,9 @@
+jenkins:
+  systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code plugin\n\n"
+globalNodeProperties:
+  - envVars:
+      env:
+        - key: VARIABLE1
+          value: foo
+        - key: VARIABLE2
+          value: bar


### PR DESCRIPTION
In some cases plugin might be not desired in the JFR setup. This change makes the plugin optional so that it activates only if it is present in the plugin set.

The extension point could be expanded in the future to support additional job types (if needed)