### PR TITLE
Add support of Job Names with folders (issue #210) + Add JobDSL plugin to the Vanilla Docker image

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -49,7 +49,7 @@ This repository includes the base image which can be built simply as...
 
 During development you can reuse the local machine build instead of doing a full build from scratch
 
-    docker build -t jenkins4eval/jenkinsfile-runner:dev -f packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile-dev .
+    docker build -t jenkins4eval/jenkinsfile-runner:dev -f packaging/docker/unix/adoptopenjdk-8-hotspot/Dockerfile-dev-vanilla .
 
 == Debugging
 

--- a/demo/job-folders/Jenkinsfile
+++ b/demo/job-folders/Jenkinsfile
@@ -1,0 +1,4 @@
+stage('Read Job Names') {
+	println "JOB_NAME: " + env.JOB_NAME
+	println "JOB_BASE_NAME: " + env.JOB_BASE_NAME
+}

--- a/demo/job-folders/JenkinsfileWithLibraryCall
+++ b/demo/job-folders/JenkinsfileWithLibraryCall
@@ -1,0 +1,14 @@
+
+stage('Read Job Names') {
+	println "JOB_NAME: " + env.JOB_NAME
+	println "JOB_BASE_NAME: " + env.JOB_BASE_NAME
+}
+
+stage('Run Shared Library Code') {
+	println "Return of Library Method infra.isTrusted() : " + infra.isTrusted().toString()
+}
+
+
+
+
+

--- a/demo/job-folders/JenkinsfileWithLibraryCall
+++ b/demo/job-folders/JenkinsfileWithLibraryCall
@@ -7,8 +7,3 @@ stage('Read Job Names') {
 stage('Run Shared Library Code') {
 	println "Return of Library Method infra.isTrusted() : " + infra.isTrusted().toString()
 }
-
-
-
-
-

--- a/demo/job-folders/README.md
+++ b/demo/job-folders/README.md
@@ -1,0 +1,55 @@
+Job Folders demo
+=================
+
+This demo shows, how to define the Job inside of a folder-structure, defined by parameter ```--job-name```  
+To create folders with additional behavior (e.g. loading of shared libraries), Job DSLs as JCasC can be used.
+
+You can run this demos after building jenkinsfile-runner image as described in [Contributing to Jenkinsfile Runner](/CONTRIBUTING.adoc#building)
+
+
+## Run with created Folder by JCasC (with Docker)  
+
+To run in folders without assigned shared libraries  
+
+```bash
+docker run --rm \
+	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
+	-v $(pwd)/demo/job-folders/folderTemplate.yaml:/usr/share/jenkins/ref/casc/folderTemplate.yaml \
+	jenkins4eval/jenkinsfile-runner:dev \
+	--job-name folderWithoutLib/exampleJob
+```	
+
+To run in folders with assigned shared libraries  
+
+```bash
+docker run --rm \
+	-v $(pwd)/demo/job-folders/JenkinsfileWithLibraryCall:/workspace/Jenkinsfile \
+	-v $(pwd)/demo/job-folders/folderTemplate.yaml:/usr/share/jenkins/ref/casc/folderTemplate.yaml \
+	jenkins4eval/jenkinsfile-runner:dev \
+	--job-name myFolder/myJob
+```
+	
+## Create folder without JCasC (with Docker)
+
+```bash
+docker run --rm \
+	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
+	jenkins4eval/jenkinsfile-runner:dev \
+	--job-name folder1/folder2/myJob
+```	
+
+## Run named job without folders (with Docker)
+
+```
+docker run --rm \
+	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
+	jenkins4eval/jenkinsfile-runner:dev \
+	--job-name myJob
+```
+
+## Run without defined name (with Docker)
+```
+docker run --rm \
+	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
+	jenkins4eval/jenkinsfile-runner:dev
+```

--- a/demo/job-folders/README.md
+++ b/demo/job-folders/README.md
@@ -15,6 +15,7 @@ To run in folders without assigned shared libraries
 docker run --rm \
 	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
 	-v $(pwd)/demo/job-folders/folderTemplate.yaml:/usr/share/jenkins/ref/casc/folderTemplate.yaml \
+	-v $(pwd)/vanilla-package/target/plugins:/usr/share/jenkins/ref/plugins \
 	jenkins4eval/jenkinsfile-runner:dev \
 	--job-name folderWithoutLib/exampleJob
 ```	
@@ -25,6 +26,7 @@ To run in folders with assigned shared libraries
 docker run --rm \
 	-v $(pwd)/demo/job-folders/JenkinsfileWithLibraryCall:/workspace/Jenkinsfile \
 	-v $(pwd)/demo/job-folders/folderTemplate.yaml:/usr/share/jenkins/ref/casc/folderTemplate.yaml \
+	-v $(pwd)/vanilla-package/target/plugins:/usr/share/jenkins/ref/plugins \
 	jenkins4eval/jenkinsfile-runner:dev \
 	--job-name myFolder/myJob
 ```
@@ -40,15 +42,15 @@ docker run --rm \
 
 ## Run named job without folders (with Docker)
 
-```
+```bash
 docker run --rm \
 	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
-	jenkins4eval/jenkinsfile-runner:dev \
+	enkins4eval/jenkinsfile-runner:dev \
 	--job-name myJob
 ```
 
 ## Run without defined name (with Docker)
-```
+```bash
 docker run --rm \
 	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
 	jenkins4eval/jenkinsfile-runner:dev

--- a/demo/job-folders/README.md
+++ b/demo/job-folders/README.md
@@ -45,7 +45,7 @@ docker run --rm \
 ```bash
 docker run --rm \
 	-v $(pwd)/demo/job-folders/Jenkinsfile:/workspace/Jenkinsfile \
-	enkins4eval/jenkinsfile-runner:dev \
+	jenkins4eval/jenkinsfile-runner:dev \
 	--job-name myJob
 ```
 

--- a/demo/job-folders/folderTemplate.yaml
+++ b/demo/job-folders/folderTemplate.yaml
@@ -1,0 +1,49 @@
+jobs:
+ - script: >
+    folder('myFolder') {
+     displayName('Project A')
+      properties {
+       folderLibraries {
+         libraries {
+           libraryConfiguration {
+              name('Test-Folder-Libraries') 
+              defaultVersion('1.0')
+              implicit(true)
+              retriever {
+                legacySCM {
+                  scm {
+                    gitSCM {
+                      userRemoteConfigs {
+                        userRemoteConfig {
+                          url('https://github.com/jenkins-infra/pipeline-library.git')
+                          name('test-libraries')
+                          refspec('')
+                          credentialsId('')
+                        }
+                      }
+                      branches {
+                        branchSpec {
+                          name('*/master')
+                        }
+                      }
+                      doGenerateSubmoduleConfigurations(false)
+                      browser{}
+                      gitTool('')
+                    }
+                  }
+                }
+              }
+           }
+         }       
+       }
+      }
+    }
+ - script: >
+    folder('folderWithoutLib') {
+     displayName('Project B')
+    }
+
+tool:
+  git:
+    installations:   
+    - name: "jgitapache"

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -45,7 +45,7 @@ public class Runner {
      */
     public int run(PipelineRunOptions runOptions) throws Exception { 
         String[] jobPathNames = runOptions.jobName.split("/");
-
+        
         for (int i=0; i < jobPathNames.length; i++) {
             try {
                 Jenkins.checkGoodName(jobPathNames[i]);
@@ -125,7 +125,7 @@ public class Runner {
         return b.getResult().ordinal;
     }
 
-    private Folder createOrReturnFolder(Folder addToFolder, String folderName) {        
+    private Folder createOrReturnFolder(Folder addToFolder, String folderName) throws IOException {        
         try {
             Jenkins j = Jenkins.get();
 
@@ -137,7 +137,8 @@ public class Runner {
             Folder folder = j.getItem(folderName, addToFolder.getItemGroup(), Folder.class);
             return folder !=null ? folder : addToFolder.createProject(Folder.class, folderName);
         } catch (IOException ex) {
-            return null;
+            System.err.println(String.format("Error creating folder '%s':%s", folderName, ex.getMessage()));
+            throw ex;
         }   
     }   
     

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -43,14 +43,10 @@ public class Runner {
     /**
      * Main entry point invoked by the setup module
      */
-    public int run(PipelineRunOptions runOptions) throws Exception {
-        
-
-
+    public int run(PipelineRunOptions runOptions) throws Exception { 
         String[] jobPathNames = runOptions.jobName.split("/");
 
-        for(int i=0; i < jobPathNames.length; i++)
-        {
+        for (int i=0; i < jobPathNames.length; i++) {
             try {
                 Jenkins.checkGoodName(jobPathNames[i]);
             } catch (Failure e) {
@@ -59,26 +55,21 @@ public class Runner {
             } 
         }
 
-
         Folder folderInScope = null;
         WorkflowJob w = null;       
 
         //create Folder structure
-        for(int i=0; i < jobPathNames.length -1; i++)
-        {
+        for (int i=0; i < jobPathNames.length -1; i++) {
             folderInScope = createOrReturnFolder(folderInScope, jobPathNames[i]);
         }
 
         //add Pipeline to Folder
-        if(folderInScope!=null)
-        {
+        if (folderInScope!=null) {
             w = folderInScope.createProject(WorkflowJob.class, jobPathNames[jobPathNames.length -1]);
-        } else
-        {
+        } else {
             w = Jenkins.get().createProject(WorkflowJob.class, jobPathNames[jobPathNames.length -1]);
-        }
-        
-        
+        }     
+
         w.updateNextBuildNumber(runOptions.buildNumber);
         w.setResumeBlocked(true);
         List<Action> pipelineActions = new ArrayList<>(3);
@@ -135,24 +126,20 @@ public class Runner {
     }
 
     private Folder createOrReturnFolder(Folder addToFolder, String folderName) {        
-
-        try{
+        try {
             Jenkins j = Jenkins.get();
-            if(addToFolder==null)
-            {           
-                
+
+            if(addToFolder==null) {
                 Folder folder = j.getItem(folderName, j, Folder.class);
                 return  folder!=null ? folder : j.createProject(Folder.class, folderName);
             }
 
             Folder folder = j.getItem(folderName, addToFolder.getItemGroup(), Folder.class);
             return folder !=null ? folder : addToFolder.createProject(Folder.class, folderName);
-        } catch(java.io.IOException e) {
+        } catch (IOException ex) {
             return null;
-        }
-   
-    }
-    
+        }   
+    }   
     
     private Action createParametersAction(PipelineRunOptions runOptions) {
       return new ParametersAction(runOptions.workflowParameters
@@ -189,5 +176,4 @@ public class Runner {
             }
         }
     }
-
 }

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>pipeline-as-yaml</artifactId>
       <version>0.12-rc</version>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>job-dsl</artifactId>
+        <version>1.77</version>
+    </dependency>
 
     <!-- Upper bounds -->
     <dependency>


### PR DESCRIPTION
allows parameter ```--job-name``` to create a job inside a folder-structure.
The parameter will be splitted at ```/``` to allow creation and assignment of jobs to specific folders.

Folders can be created inside ```Runner``` (if not created otherwise) or by Job DSL to allow introduction of additional library-settings etc.
