### PR TITLE
Update Eclipse Jetty from 9.4.34 to 9.4.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ THE SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
     <jenkins.version>2.263.1</jenkins.version>
-    <jetty.version>9.4.34.v20201102</jetty.version>
+    <jetty.version>9.4.39.v20210325</jetty.version>
     <jenkins-test-harness.version>1521.vaea1e973d086</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <findbugs.failOnError>false</findbugs.failOnError>


### PR DESCRIPTION
Just a bump to the recent version. There should be no changes impacting Jenkinsfile Runner mode
Changelog: https://github.com/eclipse/jetty.project/releases

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
