### PR TITLE
Manually follow http redirect when needed

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
@@ -137,9 +137,7 @@ public abstract class JenkinsLauncherCommand implements Callable<Integer> {
 
         // Connections won't automatically redirect across different protocols, i.e. going
         // from http to https. We have to handle that ourselves.
-        boolean redirecting = REDIRECT_STATUSES.contains(status);
-
-        if (redirecting) {
+        if (REDIRECT_STATUSES.contains(status)) {
             String newUrl = connection.getHeaderField("Location");
             System.out.println("Following redirect...");
             connection = (HttpURLConnection) new URL(newUrl).openConnection();


### PR DESCRIPTION
While trying to run the `jenkinsfile-runner` from the command line, without the extra `-w` option to point to a war file, I noticed that the app tried to download the latest `jenkins.war` but fails because the target url of `http://updates.jenkins.io/download/war/2.277.4/jenkins.war` redirects across schemes (`http` -> `https`) to `https://get.jenkins.io/war-stable/2.277.4/jenkins.war`.  This jump of schemes is not handle automatically by Java's `HttpURLConnection` and must be dealt with manually.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
