### PR TITLE
Fix compilation error on bootstrap module

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -27,6 +27,11 @@
       <groupId>io.jenkins.lib</groupId>
       <artifactId>support-log-formatter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Getting a compilation failure on the `bootstrap` module while trying to do a `mvn clean package` from the root of the project.

The error is complaining about being unable to find `javax.annotation.PostConstruct` in `bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java`.

Adding the `javax.annotation-api` dependency to the `bootstrap` module makes things happy.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
