### PR TITLE
Added a 'lint' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ demo/cwp-jdk11/source/
 **/.settings/
 tests/*.log
 
+app/jenkinsfile-runner*/

--- a/README.adoc
+++ b/README.adoc
@@ -118,6 +118,7 @@ Supported commands:
 
 * `run` - Runs the Jenkinsfile.
    This command also runs by default if no subcommands specified.
+* `lint` - Lints the Jenkinsfile without actually running it.
 * `cli` - Runs interactive https://www.jenkins.io/doc/book/managing/cli/[Jenkins CLI] from where you can access all standard
    Jenkins commands provided by the Jenkins core and installed plugins:
    `list-plugins`, `groovy`, `groovysh`, etc.

--- a/README.adoc
+++ b/README.adoc
@@ -119,6 +119,7 @@ Supported commands:
 * `run` - Runs the Jenkinsfile.
    This command also runs by default if no subcommands specified.
 * `lint` - Lints the Jenkinsfile without actually running it.
+   Only applicable to Declarative Pipeline.
 * `cli` - Runs interactive https://www.jenkins.io/doc/book/managing/cli/[Jenkins CLI] from where you can access all standard
    Jenkins commands provided by the Jenkins core and installed plugins:
    `list-plugins`, `groovy`, `groovysh`, etc.

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java
@@ -2,15 +2,15 @@ package io.jenkins.jenkinsfile.runner.bootstrap;
 
 
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.LintJenkinsfileCommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunCLICommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.VersionCommand;
+import java.util.concurrent.Callable;
 import picocli.AutoComplete;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-
-import java.util.concurrent.Callable;
 
 /**
  * Main entry point for the Jenkinsfile Runner execution.
@@ -19,7 +19,8 @@ import java.util.concurrent.Callable;
  * @author Oleg Nenashev
  */
 @Command(name = "jenkinsfile-runner", versionProvider = Util.VersionProviderImpl.class, sortOptions = false, mixinStandardHelpOptions = true,
-        subcommands = {RunJenkinsfileCommand.class, RunCLICommand.class, AutoComplete.GenerateCompletion.class, VersionCommand.class, CommandLine.HelpCommand.class})
+        subcommands = {RunJenkinsfileCommand.class, RunCLICommand.class, AutoComplete.GenerateCompletion.class, VersionCommand.class, CommandLine.HelpCommand.class,
+            LintJenkinsfileCommand.class})
 public class Bootstrap implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsfileCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsfileCommand.java
@@ -1,0 +1,27 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import java.io.File;
+
+/**
+ * Super class of Jenkinsfile commands.
+ */
+public abstract class JenkinsfileCommand extends JenkinsLauncherCommand {
+
+    /**
+     * Helper method to validate the Jenkinsfile section of the pipeline options.
+     *
+     * @param pipelineOptions the pipeline options.
+     */
+    protected void validateJenkinsfileInput(PipelineOptions pipelineOptions) {
+        if (pipelineOptions.jenkinsfile == null) {
+            pipelineOptions.jenkinsfile = new File("Jenkinsfile");
+        }
+        if (!pipelineOptions.jenkinsfile.exists()) {
+            System.err.println("no Jenkinsfile in current directory.");
+            System.exit(-1);
+        }
+        if (pipelineOptions.jenkinsfile.isDirectory()) {
+            pipelineOptions.jenkinsfile = new File(pipelineOptions.jenkinsfile, "Jenkinsfile");
+        }
+    }
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/LintJenkinsfileCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/LintJenkinsfileCommand.java
@@ -1,0 +1,29 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import java.io.IOException;
+import picocli.CommandLine;
+
+/**
+ * The "lint" command.
+ */
+@CommandLine.Command(name = "lint", description = "Lints a Jenkinsfile", mixinStandardHelpOptions = true)
+public class LintJenkinsfileCommand extends JenkinsfileCommand {
+
+    @CommandLine.Mixin
+    public PipelineLintOptions pipelineLintOptions;
+
+    @Override
+    public String getAppClassName() {
+        return "io.jenkins.jenkinsfile.runner.App";
+    }
+
+    public PipelineLintOptions getPipelineLintOptions() {
+        return pipelineLintOptions;
+    }
+
+    @Override
+    public void postConstruct() throws IOException {
+        validateJenkinsfileInput(pipelineLintOptions);
+        super.postConstruct();
+    }
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineLintOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineLintOptions.java
@@ -1,0 +1,8 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+/**
+ * Contains options for linting a Jenkinsfile.
+ */
+public class PipelineLintOptions extends PipelineOptions {
+    // No extra options...yet.
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineOptions.java
@@ -1,0 +1,17 @@
+package io.jenkins.jenkinsfile.runner.bootstrap.commands;
+
+import java.io.File;
+import picocli.CommandLine;
+
+/**
+ * Contains common options required for pipeline commands.
+ */
+public abstract class PipelineOptions {
+
+    /**
+     * The path to the Jenkinsfile.
+     */
+    @CommandLine.Option(names = {"-f", "--file"},
+        description = "Path to Jenkinsfile or directory containing a Jenkinsfile, defaults to ./Jenkinsfile")
+    public File jenkinsfile;
+}

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -1,25 +1,17 @@
 package io.jenkins.jenkinsfile.runner.bootstrap.commands;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import picocli.CommandLine;
-
 import java.io.File;
 import java.util.Map;
+import picocli.CommandLine;
 
 // TODO: Split Pipeline and generic options?
 /**
  * Contains options required for a Jenkins build run.
  */
-public class PipelineRunOptions {
+public class PipelineRunOptions extends PipelineOptions {
 
     /**package**/ static final String DEFAULT_JOBNAME = "job";
-
-    /**
-     * Checked out copy of the working space.
-     */
-    @CommandLine.Option(names = { "-f", "--file" },
-            description = "Path to Jenkinsfile or directory containing a Jenkinsfile, defaults to ./Jenkinsfile")
-    public File jenkinsfile;
 
     /**
      * Workspace for the Run

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunJenkinsfileCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/RunJenkinsfileCommand.java
@@ -1,18 +1,16 @@
 package io.jenkins.jenkinsfile.runner.bootstrap.commands;
 
-import picocli.CommandLine;
-
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import picocli.CommandLine;
 
 /**
  * @author Oleg Nenashev
  * @since TODO
  */
 @CommandLine.Command(name="run", description = "Runs Jenkinsfile", mixinStandardHelpOptions = true)
-public class RunJenkinsfileCommand extends JenkinsLauncherCommand {
+public class RunJenkinsfileCommand extends JenkinsfileCommand {
 
     @CommandLine.Mixin
     public PipelineRunOptions pipelineRunOptions;
@@ -30,16 +28,8 @@ public class RunJenkinsfileCommand extends JenkinsLauncherCommand {
 
     @Override
     public void postConstruct() throws IOException {
-        if (pipelineRunOptions.jenkinsfile == null) {
-            pipelineRunOptions.jenkinsfile = new File("Jenkinsfile");
-        }
-        if (!pipelineRunOptions.jenkinsfile.exists()) {
-            System.err.println("no Jenkinsfile in current directory.");
-            System.exit(-1);
-        }
-        if (pipelineRunOptions.jenkinsfile.isDirectory()) {
-            pipelineRunOptions.jenkinsfile = new File(pipelineRunOptions.jenkinsfile, "Jenkinsfile");
-        }
+
+        validateJenkinsfileInput(pipelineRunOptions);
 
         if (pipelineRunOptions.runWorkspace != null){
             if (System.getProperty(WORKSPACES_DIR_SYSTEM_PROPERTY) != null) {

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/App.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/App.java
@@ -2,6 +2,8 @@ package io.jenkins.jenkinsfile.runner;
 
 import io.jenkins.jenkinsfile.runner.bootstrap.IApp;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsfileCommand;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.LintJenkinsfileCommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
 
 /**
@@ -12,12 +14,21 @@ public class App implements IApp {
 
     @Override
     public int run(JenkinsLauncherCommand command) throws Throwable {
-        if (!(command instanceof RunJenkinsfileCommand)) {
+        if (!(command instanceof JenkinsfileCommand)) {
             throw new IllegalStateException(
                     String.format("%s is invoked with a wrong class type. Required=%s, got=%s",
-                            App.class, RunJenkinsfileCommand.class, command.getClass()));
+                            App.class, JenkinsfileCommand.class, command.getClass()));
         }
-        JenkinsfileRunnerLauncher launcher = new JenkinsfileRunnerLauncher((RunJenkinsfileCommand) command);
+
+        JenkinsLauncher<?> launcher;
+        if (command instanceof RunJenkinsfileCommand) {
+            launcher = new JenkinsfileRunnerLauncher((RunJenkinsfileCommand) command);
+        } else if (command instanceof LintJenkinsfileCommand) {
+            launcher = new JenkinsfileLinterLauncher((LintJenkinsfileCommand) command);
+        } else {
+            // This is most likely a development time error.
+            throw new IllegalArgumentException(String.format("Unrecognised command: %s", command.getClass().getName()));
+        }
         return launcher.launch();
     }
 }

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileLinterLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileLinterLauncher.java
@@ -1,0 +1,78 @@
+package io.jenkins.jenkinsfile.runner;
+
+import hudson.security.ACL;
+import io.jenkins.cli.shaded.org.apache.commons.io.FileUtils;
+import io.jenkins.jenkinsfile.runner.bootstrap.commands.LintJenkinsfileCommand;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import org.codehaus.groovy.control.ErrorCollector;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
+
+/**
+ * Set up of Jenkins environment for linting a single Jenkinsfile.
+ */
+public class JenkinsfileLinterLauncher extends JenkinsLauncher<LintJenkinsfileCommand> {
+
+    public static final String CONVERTER_CLASS_NAME = "org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter";
+
+    public JenkinsfileLinterLauncher(LintJenkinsfileCommand command) {
+        super(command);
+    }
+
+    //TODO: add support of timeout
+
+    /**
+     * Launch the Jenkins instance
+     * No time out and no output message
+     */
+    @Override
+    protected int doLaunch() throws Exception {
+        // So that the payload code has all the access to the system
+        ACL.impersonate(ACL.SYSTEM);
+
+        Class<?> cc = command.hasClass(CONVERTER_CLASS_NAME) ? Class.forName(CONVERTER_CLASS_NAME) : getConverterClassFromJar();
+        try {
+            // Attempt to call the scriptToPipelineDef method of the Converter class. This is the same as what
+            // happens when a Jenkinsfile is POSTed to $JENKINS_URL/pipeline-model-converter/validate.
+            System.out.println("Linting...");
+            cc.getMethod("scriptToPipelineDef", String.class).invoke(cc.newInstance(), getJenkinsfileAsString());
+            System.out.println("Done");
+            return 0;
+        } catch (Exception e) {
+            // If the linting fails, we're expecting to catch an InvocationTargetException, which
+            // wraps a MultipleCompilationErrorsException, which contains the linting errors.
+            if (e instanceof InvocationTargetException) {
+                Throwable targetException = ((InvocationTargetException) e).getTargetException();
+                if (targetException instanceof MultipleCompilationErrorsException) {
+                    ErrorCollector errorCollector = ((MultipleCompilationErrorsException) targetException).getErrorCollector();
+                    if (errorCollector != null && errorCollector.hasErrors()) {
+                        // Deliberately not using a try-with-resource here because, on close, I don't want to close down
+                        // stdout.
+                        PrintWriter pw = new PrintWriter(System.out, true);
+                        for (Object error : errorCollector.getErrors()) {
+                            if (error instanceof SyntaxErrorMessage) {
+                                ((SyntaxErrorMessage) error).write(pw, null);
+                            }
+                        }
+                    }
+                }
+                // Return a non-zero exit code.
+                return 1;
+            } else {
+                // Wasn't expecting this. Rethrow.
+                throw e;
+            }
+        }
+    }
+
+    private String getJenkinsfileAsString() throws IOException {
+        return FileUtils.readFileToString(command.pipelineLintOptions.jenkinsfile, StandardCharsets.UTF_8);
+    }
+
+    private Class<?> getConverterClassFromJar() throws IOException, ClassNotFoundException {
+        return getClassFromJar(CONVERTER_CLASS_NAME);
+    }
+}

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsfileRunnerLauncher.java
@@ -1,11 +1,8 @@
 package io.jenkins.jenkinsfile.runner;
 
 import hudson.security.ACL;
-import io.jenkins.jenkinsfile.runner.bootstrap.ClassLoaderBuilder;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
-
-import java.io.File;
 import java.io.IOException;
 
 /**
@@ -37,15 +34,6 @@ public class JenkinsfileRunnerLauncher extends JenkinsLauncher<RunJenkinsfileCom
     }
 
     private Class<?> getRunnerClassFromJar() throws IOException, ClassNotFoundException {
-        ClassLoader cl = new ClassLoaderBuilder(jenkins.getPluginManager().uberClassLoader)
-                .collectJars(command.getPayloadJarDir())
-                .make();
-        Thread.currentThread().setContextClassLoader(cl);
-        return cl.loadClass(RUNNER_CLASS_NAME);
-    }
-
-    @Override
-    protected String getThreadName() {
-        return "Executing " + env.displayName();
+        return getClassFromJar(RUNNER_CLASS_NAME);
     }
 }

--- a/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/JFRTestUtil.java
+++ b/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/JFRTestUtil.java
@@ -1,20 +1,18 @@
 package io.jenkins.jenkinsfile.runner.vanilla;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.RunJenkinsfileCommand;
-
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.CheckReturnValue;
-import picocli.CommandLine;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import picocli.CommandLine;
 
 import static org.junit.Assert.assertTrue;
 
@@ -50,12 +48,35 @@ public class JFRTestUtil {
         return runAsCLI(jenkinsfile, null);
     }
 
+    /**
+     * Executes JFR "lint" using the CLI routines
+     */
+    @CheckReturnValue
+    public static int lintAsCLI(File jenkinsfile) throws Throwable {
+        return executeAsCLI(jenkinsfile, "lint", null);
+    }
 
     /**
-     * Runs JFR using the CLI routines
+     * Executes JFR "lint" using the CLI routines
+     */
+    @CheckReturnValue
+    public static int lintAsCLI(File jenkinsfile, @CheckForNull Collection<String> additionalArgs) throws Throwable {
+        return executeAsCLI(jenkinsfile, "lint", additionalArgs);
+    }
+
+    /**
+     * Executes JFR "run" using the CLI routines
      */
     @CheckReturnValue
     public static int runAsCLI(File jenkinsfile, @CheckForNull Collection<String> additionalArgs) throws Throwable {
+        return executeAsCLI(jenkinsfile, "run", additionalArgs);
+    }
+
+    /**
+     * Executes JFR using the CLI routines
+     */
+    @CheckReturnValue
+    private static int executeAsCLI(File jenkinsfile, String command, @CheckForNull Collection<String> additionalArgs) throws Throwable {
         File vanillaTarget = new File("target");
         File warDir = new File(vanillaTarget, "war");
         File pluginsDir = new File(vanillaTarget, "plugins");
@@ -63,6 +84,7 @@ public class JFRTestUtil {
         assertTrue("Plugins directory must exist when running tests", pluginsDir.exists());
 
         List<String> basicArgs = Arrays.asList(
+                command,
                 "-w", warDir.getAbsolutePath(),
                 "-p", pluginsDir.getAbsolutePath(),
                 "-f", jenkinsfile.getAbsolutePath());


### PR DESCRIPTION
Added a `lint` command, which is akin to when a Jenkinsfile is POSTed to `$JENKINS_URL/pipeline-model-converter/validate`.

This has the benefits of being:
1. quicker to lint files because, after the validation stage, if the file passes, the pipeline isn't then executed.
2. safer to lint files because, after the validation stage, the pipeline isn't executed, which might have unwanted effects or change the state of other systems.

Running...
![jfr-run](https://user-images.githubusercontent.com/38104239/119974805-0ccde680-bfad-11eb-9e3e-6ba8aae121ff.gif)

...vs. linting...
![jfr-lint](https://user-images.githubusercontent.com/38104239/119974835-15262180-bfad-11eb-9128-96b9296ded1f.gif)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
