### PR TITLE
Update Jenkins to 2.289.1, use the latest plugins BOM

### DIFF
--- a/demo/cwp/packager-config.yml
+++ b/demo/cwp/packager-config.yml
@@ -21,7 +21,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.277.2"
+    version: "2.289.1"
 plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "script-security"

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@ THE SOFTWARE.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
-    <jenkins.version>2.277.2</jenkins.version>
-    <jenkins.bom.baseline>bom-2.277.x</jenkins.bom.baseline>
-    <jenkins.bom.version>831.v9814430e6383</jenkins.bom.version>
+    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.bom.baseline>bom-2.289.x</jenkins.bom.baseline>
+    <jenkins.bom.version>841.vd6e713d848ab</jenkins.bom.version>
     <jetty.version>9.4.39.v20210325</jetty.version>
     <jenkins-test-harness.version>1565.v51970ebd7896</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -50,10 +50,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>ssh-cli-auth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>slave-installer</artifactId>
     </dependency>
     <dependency>
@@ -71,10 +67,6 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>systemd-slave-installer</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>sshd</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Subj. refreshes the Jenkinsfile Runner and removes support for SSHD we do not use anyway

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
