### PR TITLE
Removing JSR 250 `@PostConstruct`

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java
@@ -27,7 +27,6 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.Callable;
-import javax.annotation.PostConstruct;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -76,7 +75,6 @@ public abstract class JenkinsLauncherCommand implements Callable<Integer> {
      */
     private File cache = new File(System.getProperty("user.home") + "/.jenkinsfile-runner/");
 
-    @PostConstruct
     @SuppressFBWarnings("DM_EXIT")
     public void postConstruct() throws IOException {
         final JenkinsLauncherOptions settings = getLauncherOptions();


### PR DESCRIPTION
Rather than #522, simply removing this annotation. I think it was probably unused, seeing as this method was already being explicitly called even in #21, and still is: https://github.com/jenkinsci/jenkinsfile-runner/blob/e76a4461a5f38d02d27d196cb600a6448431867e/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherCommand.java#L67 https://github.com/jenkinsci/jenkinsfile-runner/blob/e76a4461a5f38d02d27d196cb600a6448431867e/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/Bootstrap.java#L61
