### PR TITLE
Force to PERFORMANCE_OPTIMIZED for Pipeline execution

### DIFF
--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -1,11 +1,8 @@
 package io.jenkins.jenkinsfile.runner;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.plugins.credentials.Credentials;
-import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
@@ -16,9 +13,10 @@ import hudson.model.queue.QueueTaskFuture;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import com.cloudbees.hudson.plugins.folder.Folder;
+import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -26,7 +24,6 @@ import java.io.PrintStream;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -72,6 +69,8 @@ public class Runner {
 
         w.updateNextBuildNumber(runOptions.buildNumber);
         w.setResumeBlocked(true);
+        w.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.PERFORMANCE_OPTIMIZED));
+
         List<Action> pipelineActions = new ArrayList<>(3);
 
         boolean foundProvider = false;


### PR DESCRIPTION
For some reason, disabling resume isn't doing what I would have expected, i.e., leading to `PERFORMANCE_OPTIMIZED` being used as the durability level. So hey, let's be a little heavy-handed and just set the durability hint for the newly-created job directly.

This also resulted in my IDE cleaning up `Runner.java`'s imports and I decided to allow it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
