### PR TITLE
Stop setting `useAntClassLoader` which nothing consumes

### DIFF
--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
@@ -24,7 +24,6 @@
  */
 package io.jenkins.jenkinsfile.runner;
 
-import hudson.ClassicPluginStrategy;
 import hudson.CloseProofOutputStream;
 import hudson.DNSMultiCast;
 import hudson.DescriptorExtensionList;
@@ -687,10 +686,6 @@ public abstract class JenkinsEmbedder implements RootAction {
         }
         MIME_TYPES.addMimeMapping("js","application/javascript");
         Functions.DEBUG_YUI = true;
-
-        // during the unit test, predictably releasing classloader is important to avoid
-        // file descriptor leak.
-        ClassicPluginStrategy.useAntClassLoader = true;
 
         // DNS multicast support takes up a lot of time during tests, so just disable it altogether
         // this also prevents tests from falsely advertising Jenkins


### PR DESCRIPTION
This field has been [unused since 1.527](https://github.com/jenkinsci/jenkins/commit/47de54d070f67af95b4fefb6d006a72bb31a5cb8). Setting it is pointless. Stop doing so, so that one day we might be able to actually remove it.