### PR TITLE
Remove `JenkinsEmbedder.contextPath`, default to root

### DIFF
--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
@@ -120,13 +120,6 @@ public abstract class JenkinsEmbedder implements RootAction {
     protected Server server;
 
     /**
-     * Where in the {@link Server} is Jenkins deployed?
-     * <p>
-     * Just like {@link javax.servlet.ServletContext#getContextPath()}, starts with '/' but doesn't end with '/'.
-     */
-    public String contextPath = "/jenkins";
-
-    /**
      * {@link Runnable}s to be invoked at {@link #after()} .
      */
     protected List<LenientRunnable> tearDowns = new ArrayList<LenientRunnable>();
@@ -390,7 +383,7 @@ public abstract class JenkinsEmbedder implements RootAction {
      * URL ends with '/'.
      */
     public URL getURL() throws IOException {
-        return new URL("http://localhost:"+localPort+contextPath+"/");
+        return new URL("http://localhost:" + localPort + "/");
     }
 
     /**

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -77,7 +77,7 @@ public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends 
                 ? new Server(launcherOptions.httpPort)
                 : new Server(queuedThreadPool);
 
-        WebAppContext context = new WebAppContext(launcherOptions.warDir.getPath(), contextPath);
+        WebAppContext context = new WebAppContext(launcherOptions.warDir.getPath(), null);
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
         context.addBean(new NoListenerConfiguration(context));


### PR DESCRIPTION
The explicit context path `/jenkins` was blindly copied & pasted from https://github.com/jenkinsci/jenkins/commit/1ed4e4b80f73f746f9f896b092ed80005912f500. In the context of JFR it serves no purpose. If for some reason HTTP access to the JFR JVM _is_ being used, we may as well serve it from the root.

Logically this should now be `""` but Jetty inconsistently treats that like `"/"` after issuing a warning: https://github.com/eclipse/jetty.project/blob/34c03ddf1d880ac8c88c21e6530a94b4d03094b0/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java#L1636-L1640
