### PR TITLE
Interrupt any running build if the JFR JVM exits cleanly

### DIFF
--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -3,9 +3,11 @@ package io.jenkins.jenkinsfile.runner;
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import hudson.init.Terminator;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.Executor;
 import hudson.model.Failure;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
@@ -176,4 +178,17 @@ public class Runner {
             }
         }
     }
+
+    @Terminator
+    public static void stopBuilds() throws Exception {
+        for (WorkflowJob p : Jenkins.get().allItems(WorkflowJob.class)) {
+            for (WorkflowRun b : p.getBuilds()) {
+                Executor exec = b.getExecutor();
+                if (exec != null) {
+                    exec.interrupt();
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Untested, but should offer better cleanup behavior in case the Pipeline is using any external resources.
