### PR TITLE
Option to keep Jenkinsfile Runner running upon job completion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -164,6 +164,8 @@ Advanced arguments:
 * `--httpPort` - Port for exposing the web server and Jenkins Web UI from Jenkinsfile Runner.
   Disabled by default.
 * `--httpPath` - The root path/prefix for expositng the web server and Jenkins Web UI from Jenkinsfile Runner.
+* `--openWebUI` - Open Jenkins Web UI in the default browser, `--httpPort` is expected to be defined together with this option.
+* `--waitOnExit` - Keep Jenkinsfile Runner running upon job completion without various sleep() hacks in the Pipeline.
 * `--agentPort` - Port for connecting inbound Jenkins agents (over JNLP or WebSockets).
   Disabled by default.
 

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/JenkinsLauncherOptions.java
@@ -76,6 +76,10 @@ public class JenkinsLauncherOptions {
             description = "Open Jenkins Web UI in the default browser, '--httpPort' is expected to be defined together with this option")
     public boolean openWebUI;
 
+    @CommandLine.Option(names = "--waitOnExit",
+            description = "Keep Jenkinsfile Runner running upon job completion without various sleep() hacks in the Pipeline")
+    public boolean waitOnExit;
+
     @CheckForNull
     @CommandLine.Option(names = "--agentPort",
             description = "Port for connecting inbound Jenkins agents (over JNLP or WebSockets). Disabled by default")

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.DispatcherType;
@@ -189,6 +190,15 @@ public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends 
 
     @Override
     public void after() throws Exception {
+        if (command.launcherOptions.waitOnExit) {
+            try {
+                while (true) {
+                    TimeUnit.MILLISECONDS.sleep(500);
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
         if (command.launcherOptions.skipShutdown) {
             // Skips the clean up. This was initially motivated by SLF4J leaving gnarly messages.
             // The whole JVM is going to die anyway, but without the cleanup the Jenkins termination logic won't be invoked


### PR DESCRIPTION
Option to keep Jenkinsfile Runner running upon job completion

Fixes https://github.com/jenkinsci/jenkinsfile-runner/issues/553

Shutdown checked with Ctrl+C in CLI ++ http://localhost:8080/exit and http://localhost:8080/safeExit invocation.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue