### PR TITLE
Add a simple docker example based on the community docker image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -302,9 +302,9 @@ and then to configure Jenkins so that Pipelines can properly operate in the user
 There are 2 ways to extend Jenkinsfile Runner:
 
 * Using low-level management tools, including the `--plugins` command included in CLI.
-* For Docker images only: using Custom WAR/Docker Packager which automates some build steps and allows managing Jenkinsfile Runner configuration via a single YAML file.
-
-For Docker images see link:./docs/using/EXTENDING_DOCKER.adoc[Extending Jenkinsfile Runner images] for more information and examples.
+* Docker
+** A simple example that converts a Jenkins image into a JFR can be found link:./demo/docker-simple/[here].
+** A more advanced example using the Custom WAR/Docker Packager which automates some build steps and allows managing Jenkinsfile Runner configuration via a single YAML file can be found link:./docs/using/EXTENDING_DOCKER.adoc[here].
 
 == Reporting issues
 

--- a/demo/docker-simple/Dockerfile
+++ b/demo/docker-simple/Dockerfile
@@ -1,0 +1,31 @@
+# I had trouble using jdk8
+ARG baseImage=jenkins/jenkins:latest-jdk11
+
+# Load the JFR docker image
+FROM jenkins/jenkinsfile-runner:latest as jfr
+
+# Lets configure our Jenkins image
+FROM ${baseImage}
+
+# This installs the "Pipeline" plugins
+RUN jenkins-plugin-cli --plugins workflow-aggregator
+
+# Now lets turn our existing docker container into a JFR.
+
+# The jenkins/jenkins containers run as the user "jenkins" which will prevent us from exploding files later.
+USER root
+
+# copy the files needed to run the JFR binary
+COPY --from=jfr /app /app
+
+# We need to explode the jenkins.war for JFR
+RUN cd /usr/share/jenkins && jar -xvf jenkins.war
+
+# I change the home
+# ENV JENKINS_HOME="/usr/share/jenkins/ref/"
+
+# "--withInitHooks", "/usr/share/jenkins/ref/init.groovy.d/"
+
+ENTRYPOINT ["/app/bin/jenkinsfile-runner", "-w", "/usr/share/jenkins/", "-p", "/usr/share/jenkins/ref/plugins", "-f"]
+
+CMD ["/workspace/Jenkinsfile"]

--- a/demo/docker-simple/Jenkinsfile
+++ b/demo/docker-simple/Jenkinsfile
@@ -1,0 +1,3 @@
+node() {
+    echo('Hello World!')
+}

--- a/demo/docker-simple/README.md
+++ b/demo/docker-simple/README.md
@@ -1,0 +1,50 @@
+# Create a JFR from the jenkins/jenkins Docker image
+
+This tutorial will show you how to use the community maintained [Jenkins container](https://github.com/jenkinsci/docker) and convert it into a working Jenkinsfile-Runner aka JFR.
+
+The main benefit to doing it this way is that you could use the exact same Jenkins container you run in production locally on your development machine. The community image also has plenty of documentation on how to further customise the Jenkins container.
+
+## Getting started
+
+We will first build the image localy and then run this example [job](./Jenkinsfile).
+
+1. Build the JFR image with `docker build -t jfr-test .`
+2. Now run our job with `docker run --rm -v $(pwd):/workspace jfr-test`
+   ```console
+   docker run --rm -v $(pwd):/workspace jfr-test
+   WARNING: An illegal reflective access operation has occurred
+   WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$2 (file:/usr/share/jenkins/WEB-INF/lib/guice-4.0.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
+   WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$2
+   WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+   WARNING: All illegal access operations will be denied in a future release
+   Started
+   Resume disabled by user, switching to high-performance, low-durability mode.
+   [Pipeline] Start of Pipeline
+   [Pipeline] node
+   Running on Jenkins in /tmp/jenkinsfileRunner.tmp/jfr15345197312171626702.run/workspace/job
+   [Pipeline] {
+   [Pipeline] echo
+   Hello World!
+   [Pipeline] }
+   [Pipeline] // node
+   [Pipeline] End of Pipeline
+   Finished: SUCCESS
+   ```
+
+The [Dockerfile](./Dockerfile) has additional comments to explain in more detail on how it works.
+
+## Converting an existing image
+
+In the example above we started out with a fresh image from `jenkins/jenkins`. It's likely you already have a Docker image that you use in production and that you would like to use locally as a JFR. As long as your production Jenkins was built from `jenkins/jenkins` it can be converted into a JFR with these steps:
+
+1. Build the JFR image - `docker build -t jfr-test --build-arg baseImage=${myProdImage}.` Note: You should replace the `${myProdImage}` with the name and tag of your existing Jenkins image.
+2. You can run the JFR image same as before `docker run --rm -v $(pwd):/workspace jfr-test`
+
+It's likely that you will need to pass additional options to the `jenkinsfile-runner` binary for your production Jenkins image to work locally as a JFR. For example, if you are using groovy init scripts, you would want to modify the `ENTRYPOINT` in the [Dockerfile](./Dockerfile) to looks like this:
+```Dockerfile
+ENTRYPOINT ["/app/bin/jenkinsfile-runner", "-w", "/usr/share/jenkins/", "-p", "/usr/share/jenkins/ref/plugins", "--withInitHooks", "/usr/share/jenkins/ref/init.groovy.d/", "-f"]
+```
+
+### I'm not using the jenkins/jenkins image
+
+You can still convert any Jenkins installation, regardless if it's using docker or a physical installation. By calling the `jenkinsfile-runner` binary using the correct paths. For `-w` this will be the path to the exploded `jenkins.war` and `-p` will be the correct path to where you installed in your plugins and will likely be in your `JENKINS_HOME` directory.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds a simple docker example to the `demo` directory and closes #557.

I made the change to the project `README.md` in a separate commit so that is can easily be dropped or edited as the maintainers see fit. I just wanted to add the example, feel free to present it to users how ever you see fit.

I do think it's important to change how JFR is presented to users. There are several ways of running JFR currently.

* You could run JFR locally by downlading/building the binary yourself.
* You could run JFR locally by using the JFR docker image.
* You could run JFR locally be turning the JFR docker image into a replica of the Jenkins you use in production.
* You could run JFR locally by turning your production Jenkins docker image into a JFR.

I don't really think that the first 2 use cases will have lots of users. The third use case seems to be what most of the documentation in the `Extending Docker` section/readme is about and most of the demos. I think this is the reason I struggled to use this tool for so many years, because I was trying to turn my existing Jenkins image into a JFR and not turn the JFR into a copy of my existing Jenkins image. 

Which is why I created this PR. I think the majority of users are wanting to take an existing Jenkins installation and make it run locally via CLI with JFR. I also think this will lower the burden on the JFR maintainers because JFR is actually kinda simple, at least compared to turning the JFR vanilla docker image into an exact replicate of each users Jenkins server. I think most of the issues and examples in the repo are about the Jenkins customization part because the documentation takes you down a path where you are turning the JFR docker image into Jenkins instead of the other way around.

My second point is that if you are going to start pushing the "convert Jenkins to a JFR" methodology. Then I highly recommend you standardize with the community [Jenkins](https://github.com/jenkinsci/docker) image. For example using the same file paths as they do for the war file, Jenkins home and plugins. Which I think can easily be done in #213 and would make it even easier for new users to get started with JFR and Docker. This also means all the customization of Jenkins would be pushed to the community Jenkins repo, which already is thoroughly documented and would allow for the JFR maintainers to worry about jdk versions, jbang etc and less about plugins, groovy init scripts and JCasC.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

