### PR TITLE
Add --no-build-logs option to disable writing builds logs to stdout

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -70,4 +70,9 @@ public class PipelineRunOptions extends PipelineOptions {
     @CommandLine.Option(names = { "-pc", "--pipeline-configuration" },
             description = "The Pipeline Configuration File when using the Jenkins Templating Engine")
     public File pipelineConfiguration;
+
+    @CommandLine.Option(names = { "-nbl", "--no-build-logs" },
+            description = "Disable writing build logs to stdout. " +
+                    "Plugins that handle build logs will process them as usual")
+    public boolean noBuildLogs = false;
 }

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -118,7 +118,9 @@ public class Runner {
 
         b = f.getStartCondition().get();
 
-        writeLogTo(System.out);
+        if (!runOptions.noBuildLogs) {
+          writeLogTo(System.out);
+        }
 
         f.get();    // wait for the completion
         return b.getResult().ordinal;


### PR DESCRIPTION
In cases of using a log plugin to write build logs to a log storage such as Elasticsearch/OpenSearch, Logstash, etc., there is no need to also write the build logs to stdout. This will avoid redundant log entries if for example the JFR is executed on Kubernetes with an ELK setup which writes containers logs to the some log storage.

This change proposes a new PipelineRun options in which the log lines of the actual build are not written into stdout.
The build logs are then only written if a log plugin is installed and configured in the JFR image.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
