### PR TITLE
Add --write-log-init-timeout option to allow specifying a timeout to retry writing logs to stdout

### DIFF
--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -77,7 +77,7 @@ public class PipelineRunOptions extends PipelineOptions {
     public boolean noBuildLogs = false;
 
     @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
-            description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. This option sets an overall duration in seconds for retries. A delay between retries is 100ms.
-Duration in seconds to retry writing logs to output stream.")
+            description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. " +
+                    "This option sets an overall duration in seconds for retries. A delay between retries is 100ms")
     public int writeLogRetryDuration = 1;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -76,8 +76,9 @@ public class PipelineRunOptions extends PipelineOptions {
                     "Plugins that handle build logs will process them as usual")
     public boolean noBuildLogs = false;
 
-    @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
+    @CommandLine.Option(names = { "-wlit", "--write-log-init-timeout" },
             description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. " +
-                    "This option sets an overall duration in seconds for retries. A delay between retries is 100ms")
-    public int writeLogRetryDuration = 1;
+                    " This option defines the maximum time (in seconds) to wait for build log creation." +
+                    " Defaults to 1 second.")
+    public int writeLogInitTimeoutSeconds = 1;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -76,7 +76,7 @@ public class PipelineRunOptions extends PipelineOptions {
                     "Plugins that handle build logs will process them as usual")
     public boolean noBuildLogs = false;
 
-    @CommandLine.Option(names = { "-wlrc", "--write-log-retry-count" },
-            description = "Retry count for writing logs to output stream.")
-    public int writeLogRetryCount = 10;
+    @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
+            description = "Duration in seconds to retry writing logs to output stream.")
+    public int writeLogRetryDuration = 60;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -77,6 +77,7 @@ public class PipelineRunOptions extends PipelineOptions {
     public boolean noBuildLogs = false;
 
     @CommandLine.Option(names = { "-wlrd", "--write-log-retry-duration" },
-            description = "Duration in seconds to retry writing logs to output stream.")
-    public int writeLogRetryDuration = 60;
+            description = "Initializing build log forwarding to stdout may fail if the build log has not been created yet. This option sets an overall duration in seconds for retries. A delay between retries is 100ms.
+Duration in seconds to retry writing logs to output stream.")
+    public int writeLogRetryDuration = 1;
 }

--- a/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
+++ b/bootstrap/src/main/java/io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions.java
@@ -75,4 +75,8 @@ public class PipelineRunOptions extends PipelineOptions {
             description = "Disable writing build logs to stdout. " +
                     "Plugins that handle build logs will process them as usual")
     public boolean noBuildLogs = false;
+
+    @CommandLine.Option(names = { "-wlrc", "--write-log-retry-count" },
+            description = "Retry count for writing logs to output stream.")
+    public int writeLogRetryCount = 10;
 }

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -119,7 +119,7 @@ public class Runner {
         b = f.getStartCondition().get();
 
         if (!runOptions.noBuildLogs) {
-          writeLogTo(System.out, runOptions.writeLogRetryDuration);
+          writeLogTo(System.out, runOptions.writeLogInitTimeoutSeconds);
         }
 
         f.get();    // wait for the completion
@@ -156,13 +156,13 @@ public class Runner {
       return new CauseAction(c);
     }
 
-    private void writeLogTo(PrintStream out, int retryDuration) throws IOException, InterruptedException {
+    private void writeLogTo(PrintStream out, int timeoutSeconds) throws IOException, InterruptedException {
         // read output in a retry loop,
         // writeWholeLogTo may fail with FileNotFound
         // exception on a slow/busy machine, if it takes
         // longish to create the log file
         int retryInterval = 100;
-        long durationMillis = retryDuration * 1000;
+        long timeoutMillis = timeoutSeconds * 1000;
         long startTime = System.currentTimeMillis(); 
         while (true) {
             try {
@@ -170,7 +170,7 @@ public class Runner {
                 break;
             }
             catch (FileNotFoundException | NoSuchFileException e) {
-                if ( System.currentTimeMillis() - startTime > durationMillis ) {
+                if ( System.currentTimeMillis() - startTime > timeoutMillis ) {
                     throw e;
                 }
                 Thread.sleep(retryInterval);

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -119,7 +119,7 @@ public class Runner {
         b = f.getStartCondition().get();
 
         if (!runOptions.noBuildLogs) {
-          writeLogTo(System.out);
+          writeLogTo(System.out, runOptions.writeLogRetryCount);
         }
 
         f.get();    // wait for the completion
@@ -156,9 +156,7 @@ public class Runner {
       return new CauseAction(c);
     }
 
-    private void writeLogTo(PrintStream out) throws IOException, InterruptedException {
-        final int retryCnt = 10;
-
+    private void writeLogTo(PrintStream out, int retryCnt) throws IOException, InterruptedException {
         // read output in a retry loop, by default try only once
         // writeWholeLogTo may fail with FileNotFound
         // exception on a slow/busy machine, if it takes

--- a/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
+++ b/payload/src/main/java/io/jenkins/jenkinsfile/runner/Runner.java
@@ -119,7 +119,7 @@ public class Runner {
         b = f.getStartCondition().get();
 
         if (!runOptions.noBuildLogs) {
-          writeLogTo(System.out, runOptions.writeLogRetryCount);
+          writeLogTo(System.out, runOptions.writeLogRetryDuration);
         }
 
         f.get();    // wait for the completion
@@ -156,22 +156,23 @@ public class Runner {
       return new CauseAction(c);
     }
 
-    private void writeLogTo(PrintStream out, int retryCnt) throws IOException, InterruptedException {
-        // read output in a retry loop, by default try only once
+    private void writeLogTo(PrintStream out, int retryDuration) throws IOException, InterruptedException {
+        // read output in a retry loop,
         // writeWholeLogTo may fail with FileNotFound
         // exception on a slow/busy machine, if it takes
         // longish to create the log file
         int retryInterval = 100;
-        for (int i=0;i<=retryCnt;) {
+        long durationMillis = retryDuration * 1000;
+        long startTime = System.currentTimeMillis(); 
+        while (true) {
             try {
                 b.writeWholeLogTo(out);
                 break;
             }
             catch (FileNotFoundException | NoSuchFileException e) {
-                if ( i == retryCnt ) {
+                if ( System.currentTimeMillis() - startTime > durationMillis ) {
                     throw e;
                 }
-                i++;
                 Thread.sleep(retryInterval);
             }
         }


### PR DESCRIPTION
This contribution proposes a new PipelineRunOptions which provides an option to set a specific timeout within the runner is periodically trying to initialize the log output stream.

This option will replace the hardcoded [retrycount](https://github.com/jenkinsci/jenkinsfile-runner/compare/main...romanisb:jenkinsfile-runner:args/retry-log-write#diff-7110cdee196a5521a8cd44cb8979f4bcdef788eff8162118674aa248c89778c8L160) with a more dynamical approach.

Without increasing the duration of this retry, we occasionally ran into issues as shown below. Especially in a Kubernetes environment in which the nodes is under high utilization.

```
Cloning into '.'...
Checking out pipeline from revision master
Your branch is up to date with 'origin/master'.
Already on 'master'
Delete pipeline git clone credentials
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.thoughtworks.xstream.core.util.Fields (file:/app/repo/org/jvnet/hudson/xstream/1.4.7-jenkins-1/xstream-1.4.7-jenkins-1.jar) to field java.util.TreeMap.comparator
WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.core.util.Fields
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2021-01-15 07:50:03.002+0000 [id=1]	SEVERE	h.i.i.InstallUncaughtExceptionHandler$DefaultUncaughtExceptionHandler#uncaughtException: A thread (main/1) died unexpectedly due to an uncaught exception, this may leave your Jenkins in a bad way and is usually indicative of a bug in the code.
java.io.FileNotFoundException: /jenkins_home/jobs/job/builds/1/log (No such file or directory)
	at java.base/java.io.RandomAccessFile.open0(Native Method)
	at java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:345)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:259)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:214)
	at org.kohsuke.stapler.framework.io.LargeText$FileSession.<init>(LargeText.java:399)
	at org.kohsuke.stapler.framework.io.LargeText$2.open(LargeText.java:121)
	at org.kohsuke.stapler.framework.io.LargeText.writeLogTo(LargeText.java:212)
	at hudson.console.AnnotatedLargeText.writeLogTo(AnnotatedLargeText.java:165)
	at hudson.model.Run.writeWholeLogTo(Run.java:1556)
	at io.jenkins.jenkinsfile.runner.Runner.writeLogTo(Runner.java:134)
	at io.jenkins.jenkinsfile.runner.Runner.run(Runner.java:94)
Caused: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.jenkins.jenkinsfile.runner.JenkinsfileRunnerLauncher.doLaunch(JenkinsfileRunnerLauncher.java:32)
	at io.jenkins.jenkinsfile.runner.JenkinsLauncher.launch(JenkinsLauncher.java:83)
	at io.jenkins.jenkinsfile.runner.App.run(App.java:13)
	at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.run(Bootstrap.java:312)
	at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.main(Bootstrap.java:135)
``` 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x]  Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
