### PR TITLE
Build arm64 variant of docker image as part of CD

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -115,5 +115,6 @@ jobs:
         context: .
         file: ${{ matrix.dockerfile }}
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }} ${{ matrix.extra-tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Buildx is already used in the workflow enabling multi-platform builds
- Should resolve issues for users trying to work with the image on ARM (eg. all modern macOS)
- For example, got this error:
```
InvalidBaseImagePlatform: Base image jenkins/jenkinsfile-runner was pulled with platform "linux/amd64", expected "linux/arm64" for current build (line 1)
```

### Testing done

Was able to run clone the repo and run these command locally on an ARM Mac to make it work:
```
docker buildx build -t jenkins/jenkinsfile-runner:build-mvncache -f packaging/docker/build-mvncache/Dockerfile .
docker buildx build -t jenkins/jenkinsfile-runner -f packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile .
```

Thats by no means a complete test, but I'm not sure if there's any reasonable way to test this in the Github Action prior to merge. 


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
