### PR TITLE
Migrate jenkinsfile runner to Java 21+

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -24,7 +24,7 @@ jobs:
         distribution: temurin
     - name: Build with Maven
       working-directory: .
-      run: mvn -B package -Dset.changelist -DargLine="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+      run: mvn -B package
 
   build-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -13,15 +13,18 @@ jobs:
   build-maven:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Check out
+      uses: actions/checkout@v4
       with:
-        java-version: '11'
-        distribution: 'temurin'
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: temurin
     - name: Build with Maven
       working-directory: .
-      run: mvn -B package 
+      run: mvn -B package -Dset.changelist -DargLine="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
 
   build-docker:
     runs-on: ubuntu-latest
@@ -32,17 +35,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - alias: jre-11
-            dockerfile: packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile
+          - alias: jre-17
+            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
             tags: test
-          - alias: jre-11-alpine
-            dockerfile: packaging/docker/unix/eclipse-temurin-11-jre-alpine/Dockerfile
+          - alias: jre-17-alpine
+            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
             tags: test-alpine
     name: "Build Docker image: ${{ matrix.alias }}"
 
     steps:
-    - uses: actions/checkout@v2
-    
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1.5.0
     
@@ -67,16 +75,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - alias: jre-11
-            dockerfile: packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile
-            tag-prefix: eclipse-temurin-11-jre-
+          - alias: jre-17
+            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
+            tag-prefix: eclipse-temurin-17-jre-
             tag-latest: true
-            extra-tags: ", ghcr.io/${{ github.repository }}:jre-11"
-          - alias: jre-11-alpine
-            dockerfile: packaging/docker/unix/eclipse-temurin-11-jre-alpine/Dockerfile
-            tag-prefix: eclipse-temurin-11-jre-alpine-
+            extra-tags: ", ghcr.io/${{ github.repository }}:jre-17"
+          - alias: jre-17-alpine
+            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
+            tag-prefix: eclipse-temurin-17-jre-alpine-
             tag-latest: false
-            extra-tags: ", ghcr.io/${{ github.repository }}:alpine, ghcr.io/${{ github.repository }}:jre-11-alpine"
+            extra-tags: ", ghcr.io/${{ github.repository }}:alpine, ghcr.io/${{ github.repository }}:jre-17-alpine"
     needs:
       - build-maven
       - build-docker

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -17,10 +17,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
     - name: Build with Maven
       working-directory: .
@@ -35,11 +35,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - alias: jre-17
-            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
+          - alias: jre-21
+            dockerfile: packaging/docker/unix/eclipse-temurin-21-jre/Dockerfile
             tags: test
-          - alias: jre-17-alpine
-            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
+          - alias: jre-21-alpine
+            dockerfile: packaging/docker/unix/eclipse-temurin-21-jre-alpine/Dockerfile
             tags: test-alpine
     name: "Build Docker image: ${{ matrix.alias }}"
 
@@ -75,16 +75,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - alias: jre-17
-            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
-            tag-prefix: eclipse-temurin-17-jre-
+          - alias: jre-21
+            dockerfile: packaging/docker/unix/eclipse-temurin-21-jre/Dockerfile
+            tag-prefix: eclipse-temurin-21-jre-
             tag-latest: true
-            extra-tags: ", ghcr.io/${{ github.repository }}:jre-17"
-          - alias: jre-17-alpine
-            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
-            tag-prefix: eclipse-temurin-17-jre-alpine-
+            extra-tags: ", ghcr.io/${{ github.repository }}:jre-21"
+          - alias: jre-21-alpine
+            dockerfile: packaging/docker/unix/eclipse-temurin-21-jre-alpine/Dockerfile
+            tag-prefix: eclipse-temurin-21-jre-alpine-
             tag-latest: false
-            extra-tags: ", ghcr.io/${{ github.repository }}:alpine, ghcr.io/${{ github.repository }}:jre-17-alpine"
+            extra-tags: ", ghcr.io/${{ github.repository }}:alpine, ghcr.io/${{ github.repository }}:jre-21-alpine"
     needs:
       - build-maven
       - build-docker

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - name: Set version
         id: set-version
@@ -55,14 +55,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - alias: jre-11
-            dockerfile: packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile
-            tag-prefix: eclipse-temurin-11-jre-
-            extra-tags--pattern: ", ghcr.io/${{ github.repository }}:jre-11-$RELEASE_VERSION"
-          - alias: jre-11-alpine
-            dockerfile: packaging/docker/unix/eclipse-temurin-11-jre-alpine/Dockerfile
-            tag-prefix: eclipse-temurin-11-jre-alpine-
-            extra-tags-pattern: ", ghcr.io/${{ github.repository }}:alpine-$RELEASE_VERSION, ghcr.io/${{ github.repository }}:jre-11-alpine-$RELEASE_VERSION"
+          - alias: jre-17
+            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
+            tag-prefix: eclipse-temurin-17-jre-
+            extra-tags--pattern: ", ghcr.io/${{ github.repository }}:jre-17-$RELEASE_VERSION"
+          - alias: jre-17-alpine
+            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
+            tag-prefix: eclipse-temurin-17-jre-alpine-
+            extra-tags-pattern: ", ghcr.io/${{ github.repository }}:alpine-$RELEASE_VERSION, ghcr.io/${{ github.repository }}:jre-17-alpine-$RELEASE_VERSION"
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       - name: Set version
         id: set-version
@@ -55,14 +55,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - alias: jre-17
-            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
-            tag-prefix: eclipse-temurin-17-jre-
-            extra-tags--pattern: ", ghcr.io/${{ github.repository }}:jre-17-$RELEASE_VERSION"
-          - alias: jre-17-alpine
-            dockerfile: packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
-            tag-prefix: eclipse-temurin-17-jre-alpine-
-            extra-tags-pattern: ", ghcr.io/${{ github.repository }}:alpine-$RELEASE_VERSION, ghcr.io/${{ github.repository }}:jre-17-alpine-$RELEASE_VERSION"
+          - alias: jre-21
+            dockerfile: packaging/docker/unix/eclipse-temurin-21-jre/Dockerfile
+            tag-prefix: eclipse-temurin-21-jre-
+            extra-tags--pattern: ", ghcr.io/${{ github.repository }}:jre-21-$RELEASE_VERSION"
+          - alias: jre-21-alpine
+            dockerfile: packaging/docker/unix/eclipse-temurin-21-jre-alpine/Dockerfile
+            tag-prefix: eclipse-temurin-21-jre-alpine-
+            extra-tags-pattern: ", ghcr.io/${{ github.repository }}:alpine-$RELEASE_VERSION, ghcr.io/${{ github.repository }}:jre-21-alpine-$RELEASE_VERSION"
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -58,11 +58,11 @@ jobs:
           - alias: jre-21
             dockerfile: packaging/docker/unix/eclipse-temurin-21-jre/Dockerfile
             tag-prefix: eclipse-temurin-21-jre-
-            extra-tags--pattern: ", ghcr.io/${{ github.repository }}:jre-21-$RELEASE_VERSION"
+            extra-tags: ", ghcr.io/${{ github.repository }}:jre-21-$RELEASE_VERSION"
           - alias: jre-21-alpine
             dockerfile: packaging/docker/unix/eclipse-temurin-21-jre-alpine/Dockerfile
             tag-prefix: eclipse-temurin-21-jre-alpine-
-            extra-tags-pattern: ", ghcr.io/${{ github.repository }}:alpine-$RELEASE_VERSION, ghcr.io/${{ github.repository }}:jre-21-alpine-$RELEASE_VERSION"
+            extra-tags: ", ghcr.io/${{ github.repository }}:alpine-$RELEASE_VERSION, ghcr.io/${{ github.repository }}:jre-21-alpine-$RELEASE_VERSION"
     permissions:
       contents: read
       packages: write

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.8</version>
   </extension>
 </extensions>

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -47,11 +47,11 @@ This will generate an assembly artifact through the `appassembler-maven-plugin` 
 
 This repository includes the base image which can be built simply as...
 
-    docker build -t jenkins4eval/jenkinsfile-runner -f packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile .
+    docker build -t jenkins4eval/jenkinsfile-runner -f packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile .
 
 During development you can reuse the local machine build instead of doing a full build from scratch
 
-    docker build -t jenkins4eval/jenkinsfile-runner:dev -f packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile-dev-vanilla .
+    docker build -t jenkins4eval/jenkinsfile-runner:dev -f packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile-dev-vanilla .
 
 == Debugging
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ for (int i = 0; i < platforms.size(); ++i) {
 
                     stage('Build') {
                         timeout(60) {
-                            infra.runMaven(['clean', 'install', '-Dset.changelist', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco,run-its', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED'], '17')
+                            infra.runMaven(['clean', 'install', '-Dset.changelist', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco,run-its'], '17')
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ Map branches = [:]
 for (int i = 0; i < platforms.size(); ++i) {
     String label = platforms[i]
     branches[label] = {
-        node(label + " && docker") {
+        node("maven-17") {
             timestamps {
                 ws("platform_${label}_${branchName}_${buildNumber}") {
                     stage('Checkout') {
@@ -25,7 +25,7 @@ for (int i = 0; i < platforms.size(); ++i) {
 
                     stage('Build') {
                         timeout(60) {
-                            infra.runMaven(['clean', 'install', '-Dset.changelist', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco,run-its'], '11')
+                            infra.runMaven(['clean', 'install', '-Dset.changelist', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco,run-its', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED'], '17')
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ Map branches = [:]
 for (int i = 0; i < platforms.size(); ++i) {
     String label = platforms[i]
     branches[label] = {
-        node("maven-17") {
+        node("maven-21") {
             timestamps {
                 ws("platform_${label}_${branchName}_${buildNumber}") {
                     stage('Checkout') {
@@ -25,7 +25,7 @@ for (int i = 0; i < platforms.size(); ++i) {
 
                     stage('Build') {
                         timeout(60) {
-                            infra.runMaven(['clean', 'install', '-Dset.changelist', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco,run-its'], '17')
+                            infra.runMaven(['clean', 'install', '-Dset.changelist', '-Dmaven.test.failure.ignore=true', '-Denvironment=test', '-Ppackage-app,package-vanilla,jacoco,run-its'], '21')
                         }
                     }
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,6 +23,7 @@
               <goal>assemble</goal>
             </goals>
             <configuration>
+              <extraJvmArguments>--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED</extraJvmArguments>
               <programs>
                 <program>
                   <id>jenkinsfile-runner</id>

--- a/packaging-parent-pom/pom.xml
+++ b/packaging-parent-pom/pom.xml
@@ -176,7 +176,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.7.1</version>
             <configuration>
               <skipAssembly>${jfr.packaging.skip.assembly}</skipAssembly>
               <!-- Disabled due to https://github.com/jenkinsci/jenkinsfile-runner/issues/350
@@ -230,7 +230,7 @@
                 </goals>
                 <configuration>
                   <!--TODO: Add option to skip this step -->
-                  <minimumJavaVersion>8</minimumJavaVersion>
+                  <minimumJavaVersion>11</minimumJavaVersion>
                   <jenkinsCoreVersionOverride>${jenkins.version}</jenkinsCoreVersionOverride>
                   <outputDirectory>${project.build.directory}/plugins</outputDirectory>
                 </configuration>

--- a/packaging-slim-parent-pom/README.adoc
+++ b/packaging-slim-parent-pom/README.adoc
@@ -17,7 +17,7 @@ The parent POM prepares the following artifacts in `target`:
 
 == Usage in Docker
 
-See link:../packaging/docker/unix/eclipse-temurin-11-jre/Dockerfile-dev-slim[Dockerfile-dev-slim] for example.
+See link:../packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile-dev-slim[Dockerfile-dev-slim] for example.
 This example also uses additional optimization tricks.
 
 == Status

--- a/packaging-slim-parent-pom/pom.xml
+++ b/packaging-slim-parent-pom/pom.xml
@@ -64,7 +64,7 @@
             </goals>
             <configuration>
               <!--TODO: Add option to skip this step -->
-              <minimumJavaVersion>8</minimumJavaVersion>
+              <minimumJavaVersion>11</minimumJavaVersion>
               <jenkinsCoreVersionOverride>${jenkins.version}</jenkinsCoreVersionOverride>
               <outputDirectory>${project.build.directory}/plugins</outputDirectory>
             </configuration>

--- a/packaging/docker/README.adoc
+++ b/packaging/docker/README.adoc
@@ -23,11 +23,11 @@ The following format is used:
 ${JVM_VENDOR}-${JAVA_VERSION}[-${JVM_CLASSIFIER1}][-${JVM_CLASSIFIER2}]...[-${OS}]
 ----
 
-Examples: `eclipse-temurin-11-jre`, `eclipse-temurin-11-jre-alpine`
+Examples: `eclipse-temurin-17-jre`, `eclipse-temurin-17-jre-alpine`
 
 * `JVM_VENDOR` - source of the JVM in lowercase, e.g. Eclipse Temurin.
 * `JAVA_VERSION` - version of the JVM.
-  Right now `11` are used, fine-grain versions might be added in the future.
+  Right now `17` are used, fine-grain versions might be added in the future.
 * `JVM_CLASSIFIER` - Additional information about the JVM used in the image.
   It might refer to `jdk`/`jre` or a JVM type (e.g. `jre-alpine`, `openj9`).
   Multiple classifiers might be used.

--- a/packaging/docker/README.adoc
+++ b/packaging/docker/README.adoc
@@ -23,11 +23,11 @@ The following format is used:
 ${JVM_VENDOR}-${JAVA_VERSION}[-${JVM_CLASSIFIER1}][-${JVM_CLASSIFIER2}]...[-${OS}]
 ----
 
-Examples: `eclipse-temurin-17-jre`, `eclipse-temurin-17-jre-alpine`
+Examples: `eclipse-temurin-21-jre`, `eclipse-temurin-21-jre-alpine`
 
 * `JVM_VENDOR` - source of the JVM in lowercase, e.g. Eclipse Temurin.
 * `JAVA_VERSION` - version of the JVM.
-  Right now `17` are used, fine-grain versions might be added in the future.
+  Right now `21` are used, fine-grain versions might be added in the future.
 * `JVM_CLASSIFIER` - Additional information about the JVM used in the image.
   It might refer to `jdk`/`jre` or a JVM type (e.g. `jre-alpine`, `openj9`).
   Multiple classifiers might be used.

--- a/packaging/docker/build-mvncache/Dockerfile
+++ b/packaging/docker/build-mvncache/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.6-eclipse-temurin-11
+FROM maven:3.9.9-eclipse-temurin-17-focal
 WORKDIR /src
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 ADD . /src

--- a/packaging/docker/build-mvncache/Dockerfile
+++ b/packaging/docker/build-mvncache/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-17-focal
+FROM maven:3.9-eclipse-temurin-21
 WORKDIR /src
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 ADD . /src

--- a/packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
@@ -14,8 +14,7 @@ ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD packaging-slim-parent-pom /jenkinsfile-runner/packaging-slim-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-ADD .git /jenkinsfile-runner/.git
-RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors -DargLine="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
 
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \

--- a/packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/eclipse-temurin-17-jre-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.8.6-eclipse-temurin-11 as jenkinsfilerunner-build
+FROM maven:3.9.9-eclipse-temurin-17-focal as jenkinsfilerunner-build
 RUN apt-get update && apt-get install -y unzip
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
@@ -14,30 +14,26 @@ ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD packaging-slim-parent-pom /jenkinsfile-runner/packaging-slim-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
+ADD .git /jenkinsfile-runner/.git
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors -DargLine="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \
-# Delete HPI files and use the archive directories instead
-RUN echo "Optimizing plugins..." && \
-  cd /jenkinsfile-runner/vanilla-package/target/plugins && \
-  rm -rf *.hpi && \
-  for f in * ; do echo "Exploding $f..." && mv "$f" "$f.hpi" ; done;
-
-FROM eclipse-temurin:11.0.18_10-jre
-RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*
-
-ENV JDK_11 true
-
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
+  
+FROM eclipse-temurin:17-jre-alpine
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 2.5.0
+ENV JENKINS_PM_VERSION 2.13.2
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
+ENV JDK_17 true
 
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
+RUN apk add --update --no-cache wget git \
+    && mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
     && echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml \
-    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar
+    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar \
+    && apk del wget
 
 COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app

--- a/packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
+++ b/packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
@@ -14,8 +14,7 @@ ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD packaging-slim-parent-pom /jenkinsfile-runner/packaging-slim-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-ADD .git /jenkinsfile-runner/.git
-RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors -DargLine="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar

--- a/packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
+++ b/packaging/docker/unix/eclipse-temurin-17-jre/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.8.6-eclipse-temurin-11 as jenkinsfilerunner-build
+FROM maven:3.9.9-eclipse-temurin-17-focal as jenkinsfilerunner-build
 RUN apt-get update && apt-get install -y unzip
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
@@ -14,29 +14,26 @@ ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD packaging-slim-parent-pom /jenkinsfile-runner/packaging-slim-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
-
+ADD .git /jenkinsfile-runner/.git
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors -DargLine="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
-  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar \
-# Delete HPI files and use the archive directories instead
-RUN echo "Optimizing plugins..." && \
-  cd /jenkinsfile-runner/vanilla-package/target/plugins && \
-  rm -rf *.hpi && \
-  for f in * ; do echo "Exploding $f..." && mv "$f" "$f.hpi" ; done;
-  
-FROM eclipse-temurin:11.0.18_10-jre-alpine
+  rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
+
+FROM eclipse-temurin:17-jre
+RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*
+
+ENV JDK_17 true
+
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
-ENV JENKINS_PM_VERSION 2.5.0
+ENV JENKINS_PM_VERSION 2.13.2
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
 
 USER root
-RUN apk add --update --no-cache wget git \
-    && mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
     && echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml \
-    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar \
-    && apk del wget
+    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar
 
 COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app

--- a/packaging/docker/unix/eclipse-temurin-21-jre-alpine/Dockerfile
+++ b/packaging/docker/unix/eclipse-temurin-21-jre-alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.9.9-eclipse-temurin-17-focal as jenkinsfilerunner-build
-RUN apt-get update && apt-get install -y unzip
+FROM maven:3.9.16-eclipse-temurin-21-alpine as jenkinsfilerunner-build
+RUN apk add --no-cache unzip git
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
 ADD app /jenkinsfile-runner/app
@@ -14,25 +14,29 @@ ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD packaging-slim-parent-pom /jenkinsfile-runner/packaging-slim-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
+# BuildKit's git-source build context exposes the working tree without .git,
+# so buildnumber-maven-plugin and git-changelist-maven-extension cannot read
+# the SCM revision. Pin -Dchangelist explicitly (bypasses the extension) and
+# skip buildnumber-plugin (bypasses the goal-level git lookup).
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors -Dchangelist=-docker -Dmaven.buildNumber.skip=true
+
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
-
-FROM eclipse-temurin:17-jre
-RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*
-
-ENV JDK_17 true
-
+  
+FROM eclipse-temurin:21-jre-alpine
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
 ENV JENKINS_PM_VERSION 2.13.2
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
+ENV JDK_21 true
 
 USER root
-RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
+RUN apk add --update --no-cache wget git \
+    && mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
     && echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml \
-    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar
+    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar \
+    && apk del wget
 
 COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app

--- a/packaging/docker/unix/eclipse-temurin-21-jre/Dockerfile
+++ b/packaging/docker/unix/eclipse-temurin-21-jre/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jenkinsfile-runner:build-mvncache as jenkinsfilerunner-mvncache
 
-FROM maven:3.9.9-eclipse-temurin-17-focal as jenkinsfilerunner-build
+FROM maven:3.9.16-eclipse-temurin-21 as jenkinsfilerunner-build
 RUN apt-get update && apt-get install -y unzip
 ENV MAVEN_OPTS=-Dmaven.repo.local=/mavenrepo
 COPY --from=jenkinsfilerunner-mvncache /mavenrepo /mavenrepo
@@ -14,25 +14,29 @@ ADD packaging-parent-resources /jenkinsfile-runner/packaging-parent-resources
 ADD packaging-parent-pom /jenkinsfile-runner/packaging-parent-pom
 ADD packaging-slim-parent-pom /jenkinsfile-runner/packaging-slim-parent-pom
 ADD pom.xml /jenkinsfile-runner/pom.xml
-RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors
-
+# BuildKit's git-source build context exposes the working tree without .git,
+# so buildnumber-maven-plugin and git-changelist-maven-extension cannot read
+# the SCM revision. Pin -Dchangelist explicitly (bypasses the extension) and
+# skip buildnumber-plugin (bypasses the goal-level git lookup).
+RUN cd /jenkinsfile-runner && mvn clean package --batch-mode -ntp --show-version --errors -Dchangelist=-docker -Dmaven.buildNumber.skip=true
 # Prepare the Jenkins core
 RUN mkdir /app && unzip /jenkinsfile-runner/vanilla-package/target/war/jenkins.war -d /app/jenkins && \
   rm -rf /app/jenkins/scripts /app/jenkins/jsbundles /app/jenkins/css /app/jenkins/images /app/jenkins/help /app/jenkins/WEB-INF/detached-plugins /app/jenkins/WEB-INF/jenkins-cli.jar /app/jenkins/WEB-INF/lib/jna-4.5.2.jar
-  
-FROM eclipse-temurin:17-jre-alpine
+
+FROM eclipse-temurin:21-jre
+RUN apt-get update && apt-get install wget && rm -rf /var/lib/apt/lists/*
+
+ENV JDK_21 true
+
 ENV JENKINS_UC https://updates.jenkins.io
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/casc
 ENV JENKINS_PM_VERSION 2.13.2
 ENV JENKINS_PM_URL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${JENKINS_PM_VERSION}/jenkins-plugin-manager-${JENKINS_PM_VERSION}.jar
-ENV JDK_17 true
 
 USER root
-RUN apk add --update --no-cache wget git \
-    && mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
+RUN mkdir -p /app /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/casc /app/bin \
     && echo "jenkins: {}" >/usr/share/jenkins/ref/casc/jenkins.yaml \
-    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar \
-    && apk del wget
+    && wget $JENKINS_PM_URL -O /app/bin/jenkins-plugin-manager.jar
 
 COPY --from=jenkinsfilerunner-build /app/jenkins /app/jenkins
 COPY --from=jenkinsfilerunner-build /jenkinsfile-runner/app/target/appassembler /app

--- a/packaging/docker/unix/jenkinsfile-runner-launcher
+++ b/packaging/docker/unix/jenkinsfile-runner-launcher
@@ -6,6 +6,9 @@ fi
 if [ -n "$JDK_11" ] ; then
   export JAVA_OPTS="--illegal-access=permit $JAVA_OPTS"
 fi
+if [ -n "$JDK_17" ] ; then
+  export JAVA_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED $JAVA_OPTS"
+fi
 
 # check if the user has provided a path to the file
 if [ -z "${JENKINSFILE_PATH}" ] ; then

--- a/packaging/docker/unix/jenkinsfile-runner-launcher
+++ b/packaging/docker/unix/jenkinsfile-runner-launcher
@@ -6,7 +6,7 @@ fi
 if [ -n "$JDK_11" ] ; then
   export JAVA_OPTS="--illegal-access=permit $JAVA_OPTS"
 fi
-if [ -n "$JDK_17" ] ; then
+if [ -n "$JDK_17" ] || [ -n "$JDK_21" ] ; then
   export JAVA_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED $JAVA_OPTS"
 fi
 

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -32,6 +32,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>asm-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -146,7 +146,7 @@
           <webApp>
             <contextPath>/jenkins</contextPath>
           </webApp>
-          <minimumJavaVersion>1.${java.level}</minimumJavaVersion>
+          <minimumJavaVersion>${java.level}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>
           </systemProperties>

--- a/payload-dependencies/pom.xml
+++ b/payload-dependencies/pom.xml
@@ -70,6 +70,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.jenkins.plugins</groupId>
+          <artifactId>asm-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/payload/pom.xml
+++ b/payload/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.34</version>
+      <version>1.18.42</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.11.0</version>
+      <version>2.13.1</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.errorprone</groupId>

--- a/payload/pom.xml
+++ b/payload/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.13.1</version>
+      <version>2.14.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.errorprone</groupId>

--- a/payload/pom.xml
+++ b/payload/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>symbol-annotation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.34</version>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>pipeline-as-yaml</artifactId>
       <version>0.12-rc</version>
@@ -53,7 +58,13 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10.1</version>
+      <version>2.11.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.126</version>
+    <version>1.139</version>
     <relativePath />
   </parent>
 
@@ -66,10 +66,10 @@ THE SOFTWARE.
     <gitHubRepo>jenkinsci/jenkinsfile-runner</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>17</java.level>
-    <jenkins.version>2.462.3</jenkins.version>
-    <jenkins.bom.baseline>bom-2.462.x</jenkins.bom.baseline>
-    <jenkins.bom.version>3387.v0f2773fa_3200</jenkins.bom.version>
-    <jetty.version>10.0.24</jetty.version>
+    <jenkins.version>2.516.2</jenkins.version>
+    <jenkins.bom.baseline>bom-2.516.x</jenkins.bom.baseline>
+    <jenkins.bom.version>5353.v3dec76e40169</jenkins.bom.version>
+    <jetty.version>12.0.25</jetty.version>
     <jenkins-test-harness.version>2287.v4f0199c6eda_8</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <spotbugs.failOnError>false</spotbugs.failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,18 @@ THE SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
+        <!-- Java 17+ needs explicit module opens for XStream serialization
+             (hudson.model.ParametersAction#parameterDefinitionNames touches
+             AbstractList.modCount via reflection) and for the appassembler /
+             plugin-manager classloader plumbing. Mirrors the flags baked into
+             app/pom.xml's appassembler config so 'mvn test' has the same JVM
+             posture as the produced bin/jenkinsfile-runner script. -->
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
@@ -235,7 +247,7 @@ THE SOFTWARE.
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${maven-surefire-plugin.version}</version>
             <configuration>
-              <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true ${argLine}</argLine>
+              <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED ${argLine}</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.139</version>
+    <version>1.140</version>
     <relativePath />
   </parent>
 
@@ -69,7 +69,7 @@ THE SOFTWARE.
     <jenkins.version>2.516.2</jenkins.version>
     <jenkins.bom.baseline>bom-2.516.x</jenkins.bom.baseline>
     <jenkins.bom.version>5353.v3dec76e40169</jenkins.bom.version>
-    <jetty.version>12.0.25</jetty.version>
+    <jetty.version>12.0.27</jetty.version>
     <jenkins-test-harness.version>2287.v4f0199c6eda_8</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <spotbugs.failOnError>false</spotbugs.failOnError>
@@ -164,6 +164,13 @@ THE SOFTWARE.
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
       <!-- allow snapshots -->
+    </repository>
+    <repository>
+      <id>maven-central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.107</version>
+    <version>1.126</version>
     <relativePath />
   </parent>
 
@@ -65,12 +65,12 @@ THE SOFTWARE.
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jenkinsfile-runner</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>11</java.level>
-    <jenkins.version>2.375.4</jenkins.version>
-    <jenkins.bom.baseline>bom-2.375.x</jenkins.bom.baseline>
-    <jenkins.bom.version>2025.v816d28f1e04f</jenkins.bom.version>
-    <jetty.version>10.0.12</jetty.version>
-    <jenkins-test-harness.version>2140.ve736dc2b_b_d2c</jenkins-test-harness.version>
+    <java.level>17</java.level>
+    <jenkins.version>2.462.3</jenkins.version>
+    <jenkins.bom.baseline>bom-2.462.x</jenkins.bom.baseline>
+    <jenkins.bom.version>3387.v0f2773fa_3200</jenkins.bom.version>
+    <jetty.version>10.0.24</jetty.version>
+    <jenkins-test-harness.version>2287.v4f0199c6eda_8</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
@@ -108,7 +108,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pipeline-utility-steps</artifactId>
-        <version>2.16.0</version>
+        <version>2.16.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -135,7 +135,7 @@ THE SOFTWARE.
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>11</release>
+          <release>17</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,8 @@ THE SOFTWARE.
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/jenkinsfile-runner</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>17</java.level>
+    <java.level>21</java.level>
+    <maven.compiler.release>21</maven.compiler.release>
     <jenkins.version>2.516.2</jenkins.version>
     <jenkins.bom.baseline>bom-2.516.x</jenkins.bom.baseline>
     <jenkins.bom.version>5353.v3dec76e40169</jenkins.bom.version>
@@ -125,6 +126,17 @@ THE SOFTWARE.
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <!-- 1.31 from the Jenkins parent ships ASM that does not know Java 21
+               class files (major version 65). 1.35 understands them. -->
+          <groupId>org.kohsuke</groupId>
+          <artifactId>access-modifier-checker</artifactId>
+          <version>1.35</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <!-- to treat executable-war type of artifact correctly -->
@@ -135,7 +147,7 @@ THE SOFTWARE.
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>17</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,15 @@ THE SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>21</java.level>
     <maven.compiler.release>21</maven.compiler.release>
-    <jenkins.version>2.516.2</jenkins.version>
-    <jenkins.bom.baseline>bom-2.516.x</jenkins.bom.baseline>
-    <jenkins.bom.version>5353.v3dec76e40169</jenkins.bom.version>
+    <jenkins.version>2.555.3</jenkins.version>
+    <jenkins.bom.baseline>bom-2.555.x</jenkins.bom.baseline>
+    <jenkins.bom.version>6641.vfe1b_b_3c48a_4a_</jenkins.bom.version>
+    <!-- Jenkins core 2.555.x brings spotbugs-annotations 4.9.8 transitively;
+         the runner parent 1.140 still ships 4.9.4. Match core to satisfy
+         RequireUpperBoundDeps. -->
+    <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>
     <jetty.version>12.0.27</jetty.version>
-    <jenkins-test-harness.version>2287.v4f0199c6eda_8</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2573.vd91b_8a_43e019</jenkins-test-harness.version>
     <!--TODO: Reenable once all the issues are fixed (JENKINS-57353)-->
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
@@ -102,7 +106,34 @@ THE SOFTWARE.
       <dependency> <!-- Upper bounds prevention between Pipeline as YAML and JCAsC-->
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
+        <version>3.20.0</version>
+      </dependency>
+      <!-- Jenkins 2.555.x brings asm-api plugin 9.10.1; the Jenkins parent
+           still pins org.ow2.asm:asm at 9.9.1. Align to satisfy RequireUpperBoundDeps. -->
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-commons</artifactId>
+        <version>9.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-tree</artifactId>
+        <version>9.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-util</artifactId>
+        <version>9.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-analysis</artifactId>
+        <version>9.10.1</version>
       </dependency>
 
       <!-- Plugins -->
@@ -128,6 +159,14 @@ THE SOFTWARE.
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <!-- maven-hpi-plugin from the parent (3.1746) ships an ASM
+               that does not know class file major version 65 (Java 21).
+               3.1814 understands it. -->
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <version>3.1814.v77d15159f9b_d</version>
+        </plugin>
         <plugin>
           <!-- 1.31 from the Jenkins parent ships ASM that does not know Java 21
                class files (major version 65). 1.35 understands them. -->

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -40,13 +40,18 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-webapp</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-servlet</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <artifactId>jetty-security</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java
@@ -73,14 +73,14 @@ import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
 
 import io.jenkins.jenkinsfile.runner.util.ExecutionEnvironment;
 import io.jenkins.jenkinsfile.runner.util.JenkinsHomeLoader;
 import io.jenkins.jenkinsfile.runner.util.JenkinsRecipe;
 import io.jenkins.jenkinsfile.runner.util.LenientRunnable;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -205,9 +205,9 @@ public abstract class JenkinsEmbedder implements RootAction {
         // TODO: set NOOP API
         // jenkins.setCrumbIssuer(new TestCrumbIssuer());
 
-        jenkins.servletContext.setAttribute("app",jenkins);
-        jenkins.servletContext.setAttribute("version","?");
-        WebAppMain.installExpressionFactory(new ServletContextEvent(jenkins.servletContext));
+        jenkins.getServletContext().setAttribute("app",jenkins);
+        jenkins.getServletContext().setAttribute("version","?");
+        WebAppMain.installExpressionFactory(new ServletContextEvent(jenkins.getServletContext()));
 
         // set a default JDK to be the one that the harness is using.
         jenkins.getJDKs().add(new JDK("default",System.getProperty("java.home")));
@@ -685,7 +685,7 @@ public abstract class JenkinsEmbedder implements RootAction {
         } finally {
             jettyLevel(Level.INFO);
         }
-        MIME_TYPES.addMimeMapping("js","application/javascript");
+        // FIXME: MIME_TYPES.addMimeMapping("js","application/javascript");
         Functions.DEBUG_YUI = true;
 
         try {

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -17,21 +17,21 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.DispatcherType;
-import javax.servlet.ServletContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.ServletContext;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.ee9.webapp.Configuration;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
+import org.eclipse.jetty.ee9.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.eclipse.jetty.webapp.Configuration;
-import org.eclipse.jetty.webapp.WebAppContext;
-import org.eclipse.jetty.webapp.WebXmlConfiguration;
 
 /**
  * Shared behaviour for different modes of launching an embedded Jenkins in the context of jenkinsfile-runner.

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -88,6 +88,11 @@ public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends 
         contextPath = validateHttpPath(launcherOptions.httpPath);
         WebAppContext context = new WebAppContext(launcherOptions.warDir.getPath(), contextPath);
         context.setClassLoader(getClass().getClassLoader());
+        // Jetty 12 EE9: skip webdefault-ee9.xml. JFR runs Jenkins headlessly so the
+        // default servlet listeners (e.g. IntrospectorCleaner) are not needed; loading
+        // them via the WebAppClassLoader fails because the jetty-ee9-servlet jar lives
+        // on the server classloader, not the webapp one. Aligns with NoListenerConfiguration.
+        context.setDefaultsDescriptor(null);
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration()});
         context.addBean(new NoListenerConfiguration(context));
         server.setHandler(context);

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/NoListenerConfiguration.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/NoListenerConfiguration.java
@@ -1,11 +1,11 @@
 package io.jenkins.jenkinsfile.runner;
 
+import jakarta.servlet.ServletContextListener;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
 
 import java.util.Collections;
 
-import javax.servlet.ServletContextListener;
 
 /**
  * Kills off {@link ServletContextListener}s loaded from web.xml.

--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/PluginManagerImpl.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/PluginManagerImpl.java
@@ -1,8 +1,8 @@
 package io.jenkins.jenkinsfile.runner;
 
 import hudson.PluginManager;
+import jakarta.servlet.ServletContext;
 
-import javax.servlet.ServletContext;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.5.0</version>
             <executions>
               <execution>
                 <id>test</id>

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.12.0</version>
+      <version>1.14.0</version>
     </dependency>
 
     <!-- Tests -->

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.14.0</version>
+      <version>1.15.0</version>
     </dependency>
 
     <!-- Tests -->

--- a/vanilla-package/pom.xml
+++ b/vanilla-package/pom.xml
@@ -54,6 +54,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.jenkins.plugins</groupId>
+          <artifactId>asm-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Exclude this outdated plugin since it will fail with higher managed dependencies
          coming from the Jenkins core parent bom -->
@@ -73,12 +79,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.81</version>
+      <version>1.88</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>templating-engine</artifactId>
-      <version>2.3</version>
+      <version>2.5.3</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
@@ -95,7 +101,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.10.0</version>
+      <version>1.12.0</version>
     </dependency>
 
     <!-- Tests -->
@@ -198,7 +204,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
+            <version>3.5.2</version>
             <executions>
               <execution>
                 <id>integration-tests</id>

--- a/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/SmokeTest.java
+++ b/vanilla-package/src/test/java/io/jenkins/jenkinsfile/runner/vanilla/SmokeTest.java
@@ -109,7 +109,7 @@ public class SmokeTest {
 
         int result = new JFRTestUtil().run(jenkinsfile);
         assertThat("JFR should fail when there is no Jenkinsfile", result, not(equalTo(0)));
-        assertThat(systemOut.getLog(), containsString("FileNotFoundException"));
+        assertThat(systemOut.getLog(), containsString("NoSuchFileException"));
     }
 
     // TODO: uncomment once JFR can do something about timeouts internally
@@ -220,7 +220,7 @@ public class SmokeTest {
             System.setProperty(ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY, jcasc.getAbsolutePath());
             int result = new JFRTestUtil().runAsCLI(jenkinsfile);
             assertThat("Jenkinsfile Runner execution should have failed", result, not(equalTo(0)));
-            assertThat(systemErr.getLog(), containsString("No configurator for the following root elements globalNodeProperties"));
+            assertThat(systemErr.getLog(), containsString("No configurator for the following root elements:globalNodeProperties"));
         } finally {
             System.clearProperty(ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY);
         }


### PR DESCRIPTION
Picked up from #733. Migrating to Java 21.

Builds and runs locally at least. Not sure if the workflows here needs some Java 21 migration love as well.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
