### PR TITLE
Bugfix NPE where payload classloader did not include CLI types

### DIFF
--- a/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
+++ b/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsLauncher.java
@@ -4,6 +4,7 @@ import hudson.ClassicPluginStrategy;
 import hudson.PluginManager;
 import hudson.util.PluginServletFilter;
 import io.jenkins.jenkinsfile.runner.bootstrap.ClassLoaderBuilder;
+import io.jenkins.jenkinsfile.runner.bootstrap.SideClassLoader;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand;
 import io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherOptions;
 import io.jenkins.jenkinsfile.runner.util.JenkinsHomeLoader;
@@ -249,7 +250,9 @@ public abstract class JenkinsLauncher<T extends JenkinsLauncherCommand> extends 
     }
 
     protected Class<?> getClassFromJar(String classname) throws IOException, ClassNotFoundException {
-        ClassLoader cl = new ClassLoaderBuilder(jenkins.getPluginManager().uberClassLoader)
+        // Payload runs against the plugin uber classloader but must still see bootstrap CLI types
+        // (e.g. PipelineRunOptions) when JenkinsfileRunnerLauncher invokes Runner.run() reflectively.
+        ClassLoader cl = new ClassLoaderBuilder(new SideClassLoader(jenkins.getPluginManager().uberClassLoader))
             .collectJars(command.getPayloadJarDir())
             .make();
         Thread.currentThread().setContextClassLoader(cl);


### PR DESCRIPTION
I am trying to utilize jenkinsfile-runner.  So far no luck due to complexity in my setup.  However, without this patch I wasn't able to get jenkinsfile-runner to launch.

I encountered the bug packaged from main branch (commit before my HEAD).

How I launched it
=================

```
CASC_JENKINS_CONFIG=jenkins.yaml jenkinsfile-runner run -w ../jenkins-ng/jenkins-war/ -p ../jenkins-ng/plugins/ -f .ci/Jenkinsfile
```

And got exception

Stack trace encountered
=======================

```
java.lang.RuntimeException: Unhandled exception
	at io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand.call(JenkinsLauncherCommand.java:69)
	at io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand.call(JenkinsLauncherCommand.java:37)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at io.jenkins.jenkinsfile.runner.bootstrap.Bootstrap.main(Bootstrap.java:46)
Caused by: java.lang.NoClassDefFoundError: io/jenkins/jenkinsfile/runner/bootstrap/commands/PipelineRunOptions
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3578)
	at java.base/java.lang.Class.getMethodsRecursive(Class.java:3719)
	at java.base/java.lang.Class.getMethod0(Class.java:3705)
	at java.base/java.lang.Class.getMethod(Class.java:2393)
	at io.jenkins.jenkinsfile.runner.JenkinsfileRunnerLauncher.doLaunch(JenkinsfileRunnerLauncher.java:34)
	at io.jenkins.jenkinsfile.runner.JenkinsLauncher.launch(JenkinsLauncher.java:144)
	at io.jenkins.jenkinsfile.runner.App.run(App.java:32)
	at io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand.runJenkinsfileRunnerApp(JenkinsLauncherCommand.java:226)
	at io.jenkins.jenkinsfile.runner.bootstrap.commands.JenkinsLauncherCommand.call(JenkinsLauncherCommand.java:67)
	... 10 more
Caused by: java.lang.ClassNotFoundException: io.jenkins.jenkinsfile.runner.bootstrap.commands.PipelineRunOptions
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 20 more
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
